### PR TITLE
Codebase health metrics: plugin wiring, CI, and template migration

### DIFF
--- a/.claude/skills/ukpt-template-update/SKILL.md
+++ b/.claude/skills/ukpt-template-update/SKILL.md
@@ -60,7 +60,7 @@ git merge-file <project-file> <translated-base> <translated-new>
 
 File classes:
 
-- **Template-owned (expect clean merges):** `UKPT.md`, `gradle/wrapper/`, `build-logic/`,
+- **Template-owned (expect clean merges):** `UKPT.md`, `.github/workflows/metrics.yml`, `gradle/wrapper/`, `build-logic/`,
   `.claude/skills/ukpt-*`, `.claude/settings.json`, `gradle/libs.versions.toml` (projects add
   entries; the merge keeps both), root `build.gradle.kts`, `gradle.properties`.
 - **Project-owned (never sync):** `CLAUDE.md` — only verify it still imports `UKPT.md`

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -1,0 +1,50 @@
+name: metrics
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  metrics:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          # Full history: the metrics store branch, run parents, and README staleness dates.
+          fetch-depth: 0
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 21
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      # The store appends to the local metrics branch; seed it from the remote so history accrues.
+      - name: Fetch metrics branch
+        run: git fetch origin metrics:metrics || true
+
+      # Compile with a captured log so the build-warnings integration has input.
+      # iOS targets are skipped: Kotlin/Native iOS compilation needs a macOS host.
+      - name: Build (capture warnings)
+        run: |
+          mkdir -p build/metrics
+          ./gradlew :app:client:android:compileDebugKotlin :app:client:desktop:compileKotlin \
+            :app:client:web:compileKotlinWasmJs :app:server:compileKotlin \
+            --continue 2>&1 | tee build/metrics/build.log
+
+      - name: Collect and publish metrics
+        run: ./gradlew collectMetrics publishMetrics generateMetricsReport
+
+      - name: Push metrics branch
+        run: git push origin metrics
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: metrics-report
+          path: build/metrics/report.html

--- a/.github/workflows/metrics.yml
+++ b/.github/workflows/metrics.yml
@@ -47,4 +47,4 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: metrics-report
-          path: build/metrics/report.html
+          path: build/metrics/report

--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-07-03.1"
+  "templateVersion": "2026-07-03.2"
 }

--- a/UKPT.md
+++ b/UKPT.md
@@ -72,6 +72,18 @@ The shared module's Android / JVM / wasm targets compile transitively via the pe
 ```
 - **Unit tests**: per KMP module via the umbrella task, e.g. `./gradlew :feature:core:api:allTests :feature:core:client:allTests`; the server uses `./gradlew :app:server:test`.
 
+## Metrics
+
+Codebase health metrics are collected by the udytils metrics plugin, configured in the root `build.gradle.kts` (integrations: architecture, lines of code, README health, build warnings):
+
+```
+./gradlew collectMetrics            # gather every integration into build/metrics/run.json
+./gradlew publishMetrics            # append the run to the local `metrics` branch
+./gradlew generateMetricsReport     # render build/metrics/report.html from the series
+```
+
+CI runs this on every push to main (`.github/workflows/metrics.yml`) and pushes the `metrics` branch. Build warnings are parsed from a captured log at `build/metrics/build.log` when one exists. Collection never fails the build; metrics are a report, not a gate.
+
 ## Server persistence (Postgres)
 
 Server persistence uses the `dev.isaacudy.udytils.postgres` toolkit (Exposed + Flyway); conventions are in [docs/services.md](./platform/common/architecture/docs/services.md) (the `services.storage` section). The `:platform:server:postgres` module (Flyway migrations + codegen) is created when the first server feature needs persistence — until then the `services.storage` rules pass vacuously.

--- a/UKPT.md
+++ b/UKPT.md
@@ -79,7 +79,7 @@ Codebase health metrics are collected by the udytils metrics plugin, configured 
 ```
 ./gradlew collectMetrics            # gather every integration into build/metrics/run.json
 ./gradlew publishMetrics            # append the run to the local `metrics` branch
-./gradlew generateMetricsReport     # render build/metrics/report.html from the series
+./gradlew generateMetricsReport     # render build/metrics/report/ from the series
 ```
 
 CI runs this on every push to main (`.github/workflows/metrics.yml`) and pushes the `metrics` branch. Build warnings are parsed from a captured log at `build/metrics/build.log` when one exists. Collection never fails the build; metrics are a report, not a gate.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,8 @@ buildscript {
         // substitutions in settings.gradle.kts. With the classes on the root build classpath,
         // subprojects can apply it with a plain `plugins { id(...) }` block, no version needed.
         classpath(libs.udytils.architectureGradlePlugin)
+        // The udytils metrics Gradle plugin (same classpath mechanism as above).
+        classpath(libs.udytils.metricsGradlePlugin)
     }
 }
 
@@ -22,4 +24,20 @@ plugins {
     alias(libs.plugins.ktor) apply false
     alias(libs.plugins.kotlinKsp) apply false
     alias(libs.plugins.kotlinSerialization) apply false
+}
+
+// Applied by class rather than by id: the root project's own plugins { } block cannot see the
+// buildscript classpath above (subprojects can, which is how the architecture plugin is applied).
+apply<dev.isaacudy.udytils.metrics.gradle.MetricsPlugin>()
+
+// Codebase health metrics: `collectMetrics` gathers every integration,
+// `publishMetrics` appends the run to the `metrics` branch, and
+// `generateMetricsReport` renders build/metrics/report.html from the series.
+configure<dev.isaacudy.udytils.metrics.gradle.MetricsExtension> {
+    integrations {
+        architecture(":platform:common:architecture")
+        linesOfCode()
+        readmeHealth()
+        buildWarnings()
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ apply<dev.isaacudy.udytils.metrics.gradle.MetricsPlugin>()
 
 // Codebase health metrics: `collectMetrics` gathers every integration,
 // `publishMetrics` appends the run to the `metrics` branch, and
-// `generateMetricsReport` renders build/metrics/report.html from the series.
+// `generateMetricsReport` renders build/metrics/report/ from the series.
 configure<dev.isaacudy.udytils.metrics.gradle.MetricsExtension> {
     integrations {
         architecture(":platform:common:architecture")

--- a/docs/template-migrations/2026-07-03.2-codebase-metrics.md
+++ b/docs/template-migrations/2026-07-03.2-codebase-metrics.md
@@ -1,0 +1,36 @@
+# Codebase health metrics
+
+The template now collects codebase health metrics with the udytils metrics plugin
+(`dev.isaacudy.udytils:metrics-gradle-plugin`): architecture data (rule counts, per-Construct
+census, exceptions, audit findings), Kotlin lines of code per module, README health, and build
+warnings parsed from a captured log. Runs are appended to a `metrics` branch (one JSON per
+commit, written with git plumbing — the branch is never checked out), and
+`generateMetricsReport` renders the series as a self-contained HTML page.
+
+## Detection
+
+The project is affected if its root `build.gradle.kts` does not apply
+`dev.isaacudy.udytils.metrics.gradle.MetricsPlugin`.
+
+## Migration
+
+1. The file sync carries the version-catalog entry (`udytils-metricsGradlePlugin`), the settings
+   substitutions (`metrics-core`, `metrics-gradle-plugin`), the root `build.gradle.kts` buildscript
+   classpath entry, plugin application, and `metrics { }` configuration, plus
+   `.github/workflows/metrics.yml`. Check each landed.
+2. The plugin needs the current `embedded-udytils` submodule (the `metrics/` modules and the
+   architecture framework's `architectureMetrics` task); the submodule bump in this update
+   carries it.
+3. Adjust the `metrics` configuration in the root `build.gradle.kts` if the project's rule module
+   lives somewhere other than `:platform:common:architecture`.
+4. Run locally to verify:
+
+```
+./gradlew collectMetrics publishMetrics generateMetricsReport
+```
+
+## Verification
+
+`collectMetrics` reports records from every configured integration, the `metrics` branch exists
+locally with one run file, and `build/metrics/report.html` renders charts for architecture, loc,
+and readme sources.

--- a/docs/template-migrations/2026-07-03.2-codebase-metrics.md
+++ b/docs/template-migrations/2026-07-03.2-codebase-metrics.md
@@ -5,7 +5,7 @@ The template now collects codebase health metrics with the udytils metrics plugi
 census, exceptions, audit findings), Kotlin lines of code per module, README health, and build
 warnings parsed from a captured log. Runs are appended to a `metrics` branch (one JSON per
 commit, written with git plumbing — the branch is never checked out), and
-`generateMetricsReport` renders the series as a self-contained HTML page.
+`generateMetricsReport` renders the series as self-contained HTML pages (a module × metric index plus one page per metric).
 
 ## Detection
 
@@ -32,5 +32,4 @@ The project is affected if its root `build.gradle.kts` does not apply
 ## Verification
 
 `collectMetrics` reports records from every configured integration, the `metrics` branch exists
-locally with one run file, and `build/metrics/report.html` renders charts for architecture, loc,
-and readme sources.
+locally with one run file, and `build/metrics/report/index.html` renders the module × metric table with a page per metric.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ urpc-processor = { module = "dev.isaacudy.udytils:urpc-processor" }
 udytils-architectureCore = { module = "dev.isaacudy.udytils:architecture-core" }
 udytils-architectureAnnotations = { module = "dev.isaacudy.udytils:architecture-annotations" }
 udytils-architectureGradlePlugin = { module = "dev.isaacudy.udytils:architecture-gradle-plugin" }
+udytils-metricsGradlePlugin = { module = "dev.isaacudy.udytils:metrics-gradle-plugin" }
 
 # Build-logic dependencies (gradle plugin classpath artifacts)
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -75,5 +75,7 @@ includeBuild("embedded-udytils") {
         substitute(module("dev.isaacudy.udytils:architecture-core")).using(project(":architecture-core"))
         substitute(module("dev.isaacudy.udytils:architecture-annotations")).using(project(":architecture-annotations"))
         substitute(module("dev.isaacudy.udytils:architecture-gradle-plugin")).using(project(":architecture-gradle-plugin"))
+        substitute(module("dev.isaacudy.udytils:metrics-core")).using(project(":metrics-core"))
+        substitute(module("dev.isaacudy.udytils:metrics-gradle-plugin")).using(project(":metrics-gradle-plugin"))
     }
 }


### PR DESCRIPTION
Wires the udytils metrics framework into the template:

- Root-project plugin application with four integrations (architecture, lines of code, README health, build warnings from a captured log); `collectMetrics` / `publishMetrics` / `generateMetricsReport` verified end-to-end locally.
- CI workflow (`.github/workflows/metrics.yml`): collects and publishes on every push to main, pushes the `metrics` branch, uploads the report artifact.
- UKPT.md Metrics section; templateVersion `2026-07-03.2` with a migration entry for downstream adoption.

Depends on isaac-udy/udytils#7 merging first — the submodule pointer references that branch. Parked for now; the report layout will likely get more polish later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)