### PR TITLE
Ship a runnable iOS app (and fix the iOS entry point)

### DIFF
--- a/.claude/skills/ukpt-new-project/SKILL.md
+++ b/.claude/skills/ukpt-new-project/SKILL.md
@@ -44,7 +44,7 @@ Ask the user for the project name and base package if not given. Then apply, pro
 
 | Template value | Becomes | Where |
 | --- | --- | --- |
-| `com.isaacudy.ukpt` | `<package>` | app shells (packages, directories, `applicationId`, bundle ids) |
+| `com.isaacudy.ukpt` | `<package>` | app shells (packages, directories, `applicationId`), and `PRODUCT_BUNDLE_IDENTIFIER` in `app/client/ios/iosApp.xcodeproj/project.pbxproj` |
 | `ukpt` (lowercase word) | `<project-name>` | app/window titles, `rootProject.name`, README |
 | `Ukpt` type prefix | `<ProjectName>` | `:feature:core` example types, app entry points |
 | `feature.ukpt` | `feature.<first-feature>` or leave | `:feature:core` example (see note) |
@@ -91,8 +91,15 @@ Run the full matrix before the first commit:
           :app:client:web:compileKotlinWasmJs :app:client:common:compileKotlinIosArm64 \
           :app:client:common:compileKotlinIosSimulatorArm64 :app:server:compileKotlin
 ./gradlew :platform:common:architecture:verifyArchitecture
-./gradlew :feature:core:client:verifyPaparazzi
+./gradlew :feature:core:client:verifyPaparazzi --no-configuration-cache
 bash .claude/skills/ukpt-verify-web/run-bundle-check.sh
+
+# iOS: the Xcode project must still build after the bundle id is renamed.
+xcodebuild -project app/client/ios/iosApp.xcodeproj -scheme iosApp \
+           -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build
 ```
+
+Compiling the iOS targets does not exercise the app — the Compose/Enro entry point only runs when the
+app launches. If anything under `iosMain` changed, also run it in a simulator (⌘R from Xcode).
 
 Then commit everything as the project's initial commit.

--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-07-13.1"
+  "templateVersion": "2026-07-14"
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,12 @@ git submodule update --init --recursive     # required, see Embedded libraries
 ./gradlew :app:server:run                                  # Server, on :8080
 ./gradlew :app:client:android:installDebug                 # Android
 ./gradlew :app:client:web:wasmJsBrowserDevelopmentRun --no-configuration-cache   # Web
+open app/client/ios/iosApp.xcodeproj                       # iOS — then run (⌘R)
 ```
+
+The iOS app has no Gradle command: an Xcode build phase invokes
+`:app:client:common:embedAndSignAppleFrameworkForXcode`, which builds `App.framework` from the shared
+module. Simulator builds are Apple Silicon only.
 
 To start a real project from the template, use the
 [`ukpt-new-project`](.claude/skills/ukpt-new-project) skill. It renames the packages and app

--- a/UKPT.md
+++ b/UKPT.md
@@ -40,8 +40,9 @@ New code may rely on APIs that only exist in a newer submodule commit.
 
 - **Desktop**: `./gradlew :app:client:desktop:run`
 - **Server** (Ktor): `./gradlew :app:server:run`
-- **Web** (dev server): `./gradlew :app:client:web:wasmJsBrowserDevelopmentRun` — then open the served URL
+- **Web** (dev server): `./gradlew :app:client:web:wasmJsBrowserDevelopmentRun --no-configuration-cache` — then open the served URL (the flag is required; see the config-cache note in Compiling)
 - **Android**: run from Android Studio, or `./gradlew :app:client:android:installDebug` to a connected device/emulator
+- **iOS**: open `app/client/ios/iosApp.xcodeproj` in Xcode and run (⌘R). There is no Gradle command: the Xcode project's "Compile Kotlin framework" build phase invokes `:app:client:common:embedAndSignAppleFrameworkForXcode`, which builds `App.framework` and puts it where the linker expects. Simulator builds are **Apple Silicon only** — `:app:client:common` declares `iosArm64` + `iosSimulatorArm64`, so the Xcode project excludes the `x86_64` simulator slice. Add an `iosX64()` target if you need Intel Macs.
 
 ## Compiling
 
@@ -54,7 +55,7 @@ After making changes, compile every platform (client + server) to verify correct
           :app:client:common:compileKotlinIosSimulatorArm64 \
           :app:server:compileKotlin
 ```
-The common module's Android / JVM / wasm targets compile transitively via the per-platform app modules; the iOS targets are built directly from `:app:client:common` (ukpt has no separate `:app:client:ios` module).
+The common module's Android / JVM / wasm targets compile transitively via the per-platform app modules; the iOS targets are built directly from `:app:client:common`. There is no `:app:client:ios` **Gradle** module — the iOS app is an Xcode project at `app/client/ios`, which consumes `App.framework` from `:app:client:common`. Compiling the iOS targets does **not** exercise the app: the Compose/Enro entry point (`iosMain/MainViewController.kt`) is only executed when the Xcode app runs, so a change to it must be verified by actually launching the app.
 
 **Web (wasm) caveat — compiling is not enough.** `compileKotlinWasmJs` only type-checks; it does **not** catch wasm bundle/runtime failures — a `node:`-scheme import pulled in by a JVM-only dependency (e.g. `ktor-client-cio`), a missing ViewModel factory (`Factory.create … not implemented`), or the macOS `.DS_Store` IC-cache crash. For any web change, build the actual bundle and run it in a browser:
 ```

--- a/app/client/common/src/iosMain/kotlin/com/isaacudy/ukpt/MainViewController.kt
+++ b/app/client/common/src/iosMain/kotlin/com/isaacudy/ukpt/MainViewController.kt
@@ -1,17 +1,26 @@
 package com.isaacudy.ukpt
 
-import androidx.compose.ui.window.ComposeUIViewController
+import dev.enro.platform.EnroUIViewController
 import platform.UIKit.UIViewController
 
 private var navigationInstalled = false
 
+/**
+ * The entry point hosted by the iOS application (`app/client/ios`).
+ *
+ * Uses Enro's [EnroUIViewController], not Compose's `ComposeUIViewController`. On iOS
+ * `rememberNavigationContainer` finds its `RootContext` by walking up the parent view controller
+ * hierarchy, and only [EnroUIViewController] attaches one. Hosting `App()` in a plain
+ * `ComposeUIViewController` compiles, but crashes at launch with "Could not find a RootContext in
+ * the parent view controller hierarchy".
+ */
 @Suppress("FunctionName", "unused")
 fun MainViewController(): UIViewController {
     if (!navigationInstalled) {
         installUkptNavigation()
         navigationInstalled = true
     }
-    return ComposeUIViewController { App() }
+    return EnroUIViewController { App() }
 }
 
 internal expect fun installUkptNavigation()

--- a/app/client/ios/iosApp.xcodeproj/project.pbxproj
+++ b/app/client/ios/iosApp.xcodeproj/project.pbxproj
@@ -1,0 +1,300 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXFileReference section */
+		1A0000000000000000000005 /* iosApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iosApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		1A0000000000000000000011 /* Exceptions for "iosApp" folder in "iosApp" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 1A0000000000000000000004 /* iosApp */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		1A0000000000000000000006 /* iosApp */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (1A0000000000000000000011 /* Exceptions for "iosApp" folder in "iosApp" target */, ); explicitFileTypes = {}; explicitFolders = (); path = iosApp; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		1A0000000000000000000008 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		1A0000000000000000000002 = {
+			isa = PBXGroup;
+			children = (
+				1A0000000000000000000006 /* iosApp */,
+				1A0000000000000000000003 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		1A0000000000000000000003 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				1A0000000000000000000005 /* iosApp.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		1A0000000000000000000004 /* iosApp */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1A000000000000000000000C /* Build configuration list for PBXNativeTarget "iosApp" */;
+			buildPhases = (
+				1A000000000000000000000A /* Compile Kotlin framework */,
+				1A0000000000000000000007 /* Sources */,
+				1A0000000000000000000008 /* Frameworks */,
+				1A0000000000000000000009 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				1A0000000000000000000006 /* iosApp */,
+			);
+			name = iosApp;
+			productName = iosApp;
+			productReference = 1A0000000000000000000005 /* iosApp.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		1A0000000000000000000001 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 2610;
+				LastUpgradeCheck = 2610;
+				TargetAttributes = {
+					1A0000000000000000000004 = {
+						CreatedOnToolsVersion = 26.1;
+					};
+				};
+			};
+			buildConfigurationList = 1A000000000000000000000B /* Build configuration list for PBXProject "iosApp" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 1A0000000000000000000002;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 1A0000000000000000000003 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				1A0000000000000000000004 /* iosApp */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		1A0000000000000000000009 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		1A000000000000000000000A /* Compile Kotlin framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Compile Kotlin framework";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Builds App.framework from :app:client:common and places it where the linker looks\n# (FRAMEWORK_SEARCH_PATHS below). Gradle reads the target architecture, SDK and configuration\n# from the environment Xcode sets, so this only works when run from Xcode.\ncd \"$SRCROOT/../../..\"\n./gradlew :app:client:common:embedAndSignAppleFrameworkForXcode\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		1A0000000000000000000007 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		1A000000000000000000000D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		1A000000000000000000000E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		1A000000000000000000000F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				// :app:client:common declares iosArm64 and iosSimulatorArm64 only. In Release,
+				// ONLY_ACTIVE_ARCH is NO, so Xcode would also request an x86_64 simulator slice and
+				// Gradle would fail with "Xcode Requested Architecture Not Configured". Simulator
+				// builds are Apple Silicon only; add an iosX64() target if you need Intel Macs.
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../common/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = iosApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					App,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.isaacudy.ukpt;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		1A0000000000000000000010 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				// :app:client:common declares iosArm64 and iosSimulatorArm64 only. In Release,
+				// ONLY_ACTIVE_ARCH is NO, so Xcode would also request an x86_64 simulator slice and
+				// Gradle would fail with "Xcode Requested Architecture Not Configured". Simulator
+				// builds are Apple Silicon only; add an iosX64() target if you need Intel Macs.
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = x86_64;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/../common/build/xcode-frameworks/$(CONFIGURATION)/$(SDK_NAME)",
+				);
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = iosApp/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-framework",
+					App,
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.isaacudy.ukpt;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		1A000000000000000000000B /* Build configuration list for PBXProject "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A000000000000000000000D /* Debug */,
+				1A000000000000000000000E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1A000000000000000000000C /* Build configuration list for PBXNativeTarget "iosApp" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1A000000000000000000000F /* Debug */,
+				1A0000000000000000000010 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 1A0000000000000000000001 /* Project object */;
+}

--- a/app/client/ios/iosApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/app/client/ios/iosApp.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/app/client/ios/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
+++ b/app/client/ios/iosApp.xcodeproj/xcshareddata/xcschemes/iosApp.xcscheme
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1A0000000000000000000004"
+               BuildableName = "iosApp.app"
+               BlueprintName = "iosApp"
+               ReferencedContainer = "container:iosApp.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1A0000000000000000000004"
+            BuildableName = "iosApp.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1A0000000000000000000004"
+            BuildableName = "iosApp.app"
+            BlueprintName = "iosApp"
+            ReferencedContainer = "container:iosApp.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/app/client/ios/iosApp/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/app/client/ios/iosApp/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app/client/ios/iosApp/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/app/client/ios/iosApp/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app/client/ios/iosApp/Assets.xcassets/Contents.json
+++ b/app/client/ios/iosApp/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/app/client/ios/iosApp/ContentView.swift
+++ b/app/client/ios/iosApp/ContentView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+import UIKit
+import App
+
+/// Hosts the shared Compose UI.
+///
+/// `MainViewController()` is the Kotlin entry point in `:app:client:common`
+/// (`iosMain/.../MainViewController.kt`). It installs Enro navigation on first call and returns a
+/// `ComposeUIViewController` wrapping `App()`, so everything below this line is shared code.
+struct ContentView: UIViewControllerRepresentable {
+    func makeUIViewController(context: Context) -> UIViewController {
+        MainViewControllerKt.MainViewController()
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}
+}

--- a/app/client/ios/iosApp/Info.plist
+++ b/app/client/ios/iosApp/Info.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<!--
+	  Compose Multiplatform refuses to start without this key (androidx.compose.ui.uikit.PlistSanityCheck):
+	  without it, the UI is capped at 60Hz on ProMotion devices. It cannot be supplied through
+	  GENERATE_INFOPLIST_FILE, which only emits keys Xcode knows about — hence this file.
+	-->
+	<key>CADisableMinimumFrameDurationOnPhone</key>
+	<true/>
+
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/app/client/ios/iosApp/iOSApp.swift
+++ b/app/client/ios/iosApp/iOSApp.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+@main
+struct iOSApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .ignoresSafeArea(.all)
+        }
+    }
+}

--- a/docs/template-migrations/2026-07-14-ios-xcode-app.md
+++ b/docs/template-migrations/2026-07-14-ios-xcode-app.md
@@ -1,0 +1,84 @@
+# The iOS app ships an Xcode project
+
+The template now includes a runnable iOS app at `app/client/ios`, and fixes the iOS entry point,
+which was broken.
+
+## What changed
+
+- **New Xcode project** at `app/client/ios/iosApp.xcodeproj`, plus a SwiftUI host (`iOSApp.swift`,
+  `ContentView.swift`), an `Info.plist` and an asset catalog. A "Compile Kotlin framework" build phase
+  runs `:app:client:common:embedAndSignAppleFrameworkForXcode`, which builds `App.framework` and puts
+  it where `FRAMEWORK_SEARCH_PATHS` expects. There is no Gradle command to run the app: open the
+  project in Xcode and press ⌘R.
+- **`iosMain/MainViewController.kt` now returns `EnroUIViewController { App() }`**, not
+  `ComposeUIViewController { App() }`.
+
+## The entry-point bug
+
+This is the part that affects existing projects.
+
+On iOS, `rememberNavigationContainer` resolves its `RootContext` by walking up the parent view
+controller hierarchy (`dev.enro.ui.findRootNavigationContext`), and only `EnroUIViewController`
+attaches one. Hosting `App()` in a plain `ComposeUIViewController` **compiles**, and every iOS compile
+task passes, but the app dies at launch:
+
+```
+kotlin.IllegalStateException: Could not find a RootContext in the parent view controller hierarchy
+    at dev.enro.ui#findRootNavigationContext
+    at dev.enro.ui#rememberNavigationContainer
+```
+
+The template shipped this broken because it had no iOS app to run: compiling the iOS targets never
+executes the entry point. Any project that copied the template's `MainViewController.kt` has the same
+latent bug and has never been able to launch on iOS.
+
+## Detection
+
+- `app/client/ios/` does not exist.
+- `iosMain/.../MainViewController.kt` calls `ComposeUIViewController { ... }` rather than
+  `EnroUIViewController { ... }`.
+
+## Migration
+
+1. Fix the entry point:
+   ```kotlin
+   import dev.enro.platform.EnroUIViewController
+
+   fun MainViewController(): UIViewController {
+       if (!navigationInstalled) {
+           installNavigation()
+           navigationInstalled = true
+       }
+       return EnroUIViewController { App() }   // was ComposeUIViewController
+   }
+   ```
+2. Copy `app/client/ios/` from the template and rename `PRODUCT_BUNDLE_IDENTIFIER` in
+   `iosApp.xcodeproj/project.pbxproj` to the project's package. Nothing else in the Xcode project is
+   template-branded.
+3. Confirm the project's `:app:client:common` declares an iOS framework binary named `App`:
+   ```kotlin
+   iosTarget.binaries.framework { baseName = "App"; isStatic = true }
+   ```
+   If it uses a different `baseName`, change `OTHER_LDFLAGS` (`-framework <name>`) to match.
+
+Two settings in the Xcode project are worth knowing about, because both cause obscure failures:
+
+- **`Info.plist` carries `CADisableMinimumFrameDurationOnPhone`.** Compose Multiplatform refuses to
+  start without it (`androidx.compose.ui.uikit.PlistSanityCheck`) — the UI would otherwise be capped
+  at 60Hz on ProMotion devices. It cannot be supplied via `GENERATE_INFOPLIST_FILE`, which only emits
+  keys Xcode knows, so the project uses an explicit `Info.plist` and excludes it from the
+  synchronized group's membership (otherwise Xcode reports "Multiple commands produce Info.plist").
+- **`EXCLUDED_ARCHS[sdk=iphonesimulator*] = x86_64`.** `:app:client:common` declares `iosArm64` and
+  `iosSimulatorArm64` only. In Release, `ONLY_ACTIVE_ARCH` is `NO`, so Xcode would otherwise request an
+  x86_64 simulator slice and Gradle fails with "Xcode Requested Architecture Not Configured". Add an
+  `iosX64()` Kotlin target if Intel Macs must run the simulator.
+
+## Verification
+
+```
+xcodebuild -project app/client/ios/iosApp.xcodeproj -scheme iosApp \
+           -destination 'generic/platform=iOS' CODE_SIGNING_ALLOWED=NO build
+```
+
+Then **launch it in a simulator** — compiling proves nothing here, since the entry-point bug above
+compiles cleanly and only fails at runtime. The app should render the `:feature:core` screen.


### PR DESCRIPTION
`:app:client:common` already built an `App.framework` for `iosArm64`/`iosSimulatorArm64`, and its build file even referred to *"an Xcode project consuming `App.framework`"* — but no such project existed. iOS was the one target that could be **compiled and never run**.

This ships that project, and fixes the entry-point bug that only became visible once it could be run.

## The bug this exposed

`iosMain/MainViewController.kt` returned `ComposeUIViewController { App() }`. On iOS, `rememberNavigationContainer` resolves its `RootContext` by walking up the parent view controller hierarchy (`dev.enro.ui.findRootNavigationContext`), and **only `EnroUIViewController` attaches one**. So the app compiled, every iOS compile task passed, and it died instantly at launch:

```
kotlin.IllegalStateException: Could not find a RootContext in the parent view controller hierarchy
    at dev.enro.ui#findRootNavigationContext
    at dev.enro.ui#rememberNavigationContainer
    at com.isaacudy.ukpt.App
```

The template shipped this broken precisely *because* there was no iOS app: compiling the iOS targets never executes the entry point. Enro's own iOS sample uses `EnroUIViewController`, which is the supported way to host a navigation container. **Any project built from the template has this latent bug and has never been able to launch on iOS.**

## The Xcode project

`app/client/ios` — a SwiftUI host whose `ContentView` wraps `MainViewController()`. A "Compile Kotlin framework" build phase invokes `:app:client:common:embedAndSignAppleFrameworkForXcode`, which builds the framework and drops it where `FRAMEWORK_SEARCH_PATHS` expects. No Gradle command: open it and press ⌘R.

Two settings are load-bearing and would be baffling to rediscover:

- **`Info.plist` carries `CADisableMinimumFrameDurationOnPhone`.** Compose Multiplatform *refuses to start* without it (`PlistSanityCheck`) — the UI would be capped at 60Hz on ProMotion. It **cannot** be supplied via `GENERATE_INFOPLIST_FILE`, which only emits keys Xcode knows, so the target uses an explicit `Info.plist` and excludes it from the synchronized group's membership (otherwise: "Multiple commands produce Info.plist").
- **`EXCLUDED_ARCHS[sdk=iphonesimulator*] = x86_64`.** The shared module declares only arm64 iOS targets; in Release `ONLY_ACTIVE_ARCH` is `NO`, so Xcode requests an x86_64 simulator slice and Gradle fails with "Xcode Requested Architecture Not Configured". **Simulator builds are Apple Silicon only** — add an `iosX64()` target if Intel Macs matter.

## Verification

Not just compiled — **launched**:

| | |
|---|---|
| Debug, simulator | ✅ builds, installs, launches, renders the `:feature:core` screen |
| Release, simulator | ✅ builds |
| Generic iOS device (arm64) | ✅ builds |
| Compile sweep (all 6 targets) | ✅ |
| `verifyArchitecture` / `verifyPaparazzi` | ✅ |

I hit both failure modes above for real during this work — the plist crash and the arch mismatch — which is why they're documented rather than guessed at.

## Drive-by fixes

Two commands broke when the configuration cache was turned on and were missed at the time. Both need `--no-configuration-cache`:
- the web run command in `UKPT.md`
- `verifyPaparazzi` in the `ukpt-new-project` skill

## Downstream

`templateVersion` → `2026-07-14`, with a migration entry. The entry-point fix is the important part for existing projects: they can adopt it without taking the Xcode project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)