### PR TITLE
Fix build conventions and snapshot safety

### DIFF
--- a/.claude/skills/ukpt-feature-slice/SKILL.md
+++ b/.claude/skills/ukpt-feature-slice/SKILL.md
@@ -31,7 +31,8 @@ Do **not** copy the literal `ukpt`/`Ukpt` from core — substitute `<name>`/`<Na
 3. **Client sources** (`feature.<name>.ui`): `<Name>Destination` in `:api`; `<Name>Screen` +
    `internal <Name>ScreenContent`, `<Name>ViewModel`, `<Name>State`, and `<name>ClientDependencies` in
    `:client` (templates.md §5).
-4. **Snapshot tests (preview-driven)** — copy `SnapshotRule.kt` and `PreviewSnapshotTest.kt` from
+4. **Snapshot tests (preview-driven)** — copy `SnapshotRule.kt`, `DirectorySnapshotHandler.kt`,
+   `DirectorySnapshotHandlerTest.kt`, and `PreviewSnapshotTest.kt` from
    `feature/core/client/src/androidHostTest/kotlin/platform/snapshot/` into the new module's
    `androidHostTest/.../platform/snapshot/`, changing PreviewSnapshotTest's scanned package to
    `feature.<name>` (templates.md §6). The Screen template's `@Preview` (§5) is what gets

--- a/.claude/skills/ukpt-feature-slice/templates.md
+++ b/.claude/skills/ukpt-feature-slice/templates.md
@@ -8,7 +8,6 @@ These mirror `:feature:core` — if core's build files change materially, update
 ```kotlin
 plugins {
     id("ukpt.kmp-library")
-    alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.kotlinKsp)
 }
 
@@ -54,7 +53,6 @@ dependencies {
 plugins {
     id("ukpt.compose-library")
     alias(libs.plugins.kotlinKsp)
-    alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.paparazzi)
 }
 
@@ -157,7 +155,6 @@ tasks.withType<Test>().configureEach {
 ```kotlin
 plugins {
     id("ukpt.jvm-library")
-    alias(libs.plugins.kotlinSerialization)
 }
 
 dependencies {
@@ -298,12 +295,13 @@ val <name>ClientDependencies = module {
 ```
 
 ## §6 — Snapshot tests (preview-driven)
-1. Copy **both** of these **verbatim** from `feature/core/client/src/androidHostTest/kotlin/platform/snapshot/`
+1. Copy **all three** of these **verbatim** from `feature/core/client/src/androidHostTest/kotlin/platform/snapshot/`
    into `feature/<name>/client/src/androidHostTest/kotlin/platform/snapshot/` (they are identical in every
    module — copy the live files rather than a snapshot here, so they can't drift):
    - `SnapshotRule.kt`
    - `DirectorySnapshotHandler.kt` — the custom Paparazzi `SnapshotHandler` that writes/verifies goldens at a
      directory-grouped path. Without it the goldens fall back to one long flat filename per preview.
+   - `DirectorySnapshotHandlerTest.kt` — regression coverage for plain-test, record, and verify behaviour.
 2. Copy `feature/core/client/src/androidHostTest/kotlin/platform/snapshot/PreviewSnapshotTest.kt` into the same
    location in the new module, changing ONE line — the package tree it scans:
    `scanPackageTrees("feature.<name>")`. That scan argument is the only intended per-module divergence.

--- a/.claude/skills/ukpt-template-update/SKILL.md
+++ b/.claude/skills/ukpt-template-update/SKILL.md
@@ -116,7 +116,7 @@ The full matrix, from UKPT.md:
           :app:client:web:compileKotlinWasmJs :app:client:common:compileKotlinIosArm64 \
           :app:client:common:compileKotlinIosSimulatorArm64 :app:server:compileKotlin
 ./gradlew :platform:common:architecture:verifyArchitecture
-./gradlew :feature:<each>:client:verifyPaparazzi
+./gradlew :feature:<each>:client:verifyPaparazzi --no-configuration-cache
 bash .claude/skills/ukpt-verify-web/run-bundle-check.sh
 ```
 

--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-07-14"
+  "templateVersion": "2026-07-15"
 }

--- a/app/client/android/build.gradle.kts
+++ b/app/client/android/build.gradle.kts
@@ -9,15 +9,18 @@ plugins {
 }
 
 private val projectNamespace = providers.gradleProperty("ukpt.projectNamespace").get()
+private val androidCompileSdk = libs.versions.android.compileSdk.get().toInt()
+private val androidMinSdk = libs.versions.android.minSdk.get().toInt()
+private val androidTargetSdk = libs.versions.android.targetSdk.get().toInt()
 
 android {
     namespace = projectNamespace
-    compileSdk = 36
+    compileSdk = androidCompileSdk
 
     defaultConfig {
         applicationId = projectNamespace
-        minSdk = 24
-        targetSdk = 36
+        minSdk = androidMinSdk
+        targetSdk = androidTargetSdk
         versionCode = 1
         versionName = "1.0"
     }

--- a/app/client/common/build.gradle.kts
+++ b/app/client/common/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("ukpt.compose-library")
     alias(libs.plugins.kotlinKsp)
-    alias(libs.plugins.kotlinSerialization)
 }
 
 private val projectNamespace = providers.gradleProperty("ukpt.projectNamespace").get()

--- a/app/client/desktop/build.gradle.kts
+++ b/app/client/desktop/build.gradle.kts
@@ -1,21 +1,12 @@
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
-    alias(libs.plugins.kotlinJvm)
+    id("ukpt.jvm-base")
     alias(libs.plugins.composeMultiplatform)
     alias(libs.plugins.composeCompiler)
 }
 
 private val projectNamespace = providers.gradleProperty("ukpt.projectNamespace").get()
-
-// Keep Java compilation aligned with the Kotlin jvmTarget (11) to satisfy the
-// JVM-target consistency check on this plain Kotlin/JVM module.
-java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
-}
 
 dependencies {
     implementation(projects.app.client.common)
@@ -37,18 +28,5 @@ compose.desktop {
             packageName = projectNamespace
             packageVersion = "1.0.0"
         }
-    }
-}
-
-// Preview-feature flags match the KMP convention plugins so this module can consume
-// :app:client:common, whose output is marked pre-release by those features.
-tasks.withType<KotlinCompile>().configureEach {
-    compilerOptions {
-        jvmTarget.set(JvmTarget.JVM_11)
-        freeCompilerArgs.addAll(
-            "-Xcontext-parameters",
-            "-Xexplicit-backing-fields",
-            "-Xexpect-actual-classes",
-        )
     }
 }

--- a/app/client/ios/iosApp/ContentView.swift
+++ b/app/client/ios/iosApp/ContentView.swift
@@ -6,7 +6,7 @@ import App
 ///
 /// `MainViewController()` is the Kotlin entry point in `:app:client:common`
 /// (`iosMain/.../MainViewController.kt`). It installs Enro navigation on first call and returns a
-/// `ComposeUIViewController` wrapping `App()`, so everything below this line is shared code.
+/// `EnroUIViewController` wrapping `App()`, so everything below this line is shared code.
 struct ContentView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
         MainViewControllerKt.MainViewController()

--- a/app/server/build.gradle.kts
+++ b/app/server/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("ukpt.jvm-server")
     alias(libs.plugins.ktor)
-    alias(libs.plugins.kotlinSerialization)
 }
 
 private val projectNamespace = providers.gradleProperty("ukpt.projectNamespace").get()

--- a/build-logic/src/main/kotlin/ukpt.jvm-base.gradle.kts
+++ b/build-logic/src/main/kotlin/ukpt.jvm-base.gradle.kts
@@ -1,0 +1,25 @@
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
+/**
+ * Base convention for every plain Kotlin/JVM module in the project.
+ *
+ * Applies: KotlinJvm
+ * Configures: Java/Kotlin bytecode target and shared Kotlin compiler options.
+ */
+plugins {
+    id("org.jetbrains.kotlin.jvm")
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(JvmTarget.JVM_11)
+        freeCompilerArgs.addAll(
+            "-Xexpect-actual-classes",
+        )
+    }
+}

--- a/build-logic/src/main/kotlin/ukpt.jvm-library.gradle.kts
+++ b/build-logic/src/main/kotlin/ukpt.jvm-library.gradle.kts
@@ -1,25 +1,15 @@
 /**
  * Convention plugin for JVM-only library/server modules.
  *
- * Applies: KotlinJvm
- * Configures: Common Kotlin compiler options.
+ * Applies: ukpt.jvm-base, KotlinSerialization
+ * Configures: Kotlin serialization runtime.
  */
 plugins {
-    id("org.jetbrains.kotlin.jvm")
+    id("ukpt.jvm-base")
     id("org.jetbrains.kotlin.plugin.serialization")
 }
 
 private val libs = versionCatalogs.named("libs")
-
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.addAll(
-            "-Xcontext-parameters",
-            "-Xexplicit-backing-fields",
-            "-Xexpect-actual-classes",
-        )
-    }
-}
 
 dependencies {
     implementation(libs.findLibrary("kotlinx-serialization").get())

--- a/build-logic/src/main/kotlin/ukpt.jvm-server.gradle.kts
+++ b/build-logic/src/main/kotlin/ukpt.jvm-server.gradle.kts
@@ -1,22 +1,12 @@
 /**
  * Convention plugin for JVM server application modules (e.g. :app:server).
  *
- * Applies: KotlinJvm, Ktor
- * Configures: Common Kotlin compiler options.
+ * Applies: ukpt.jvm-base, KotlinSerialization
  *
- * Consuming modules should set `application.mainClass` and add their own dependencies.
+ * Executable server applications should apply the Ktor plugin directly, set
+ * `application.mainClass`, and add their own dependencies.
  */
 plugins {
-    id("org.jetbrains.kotlin.jvm")
+    id("ukpt.jvm-base")
     id("org.jetbrains.kotlin.plugin.serialization")
-}
-
-kotlin {
-    compilerOptions {
-        freeCompilerArgs.addAll(
-            "-Xcontext-parameters",
-            "-Xexplicit-backing-fields",
-            "-Xexpect-actual-classes",
-        )
-    }
 }

--- a/build-logic/src/main/kotlin/ukpt.kmp-library.gradle.kts
+++ b/build-logic/src/main/kotlin/ukpt.kmp-library.gradle.kts
@@ -22,12 +22,14 @@ plugins {
 }
 
 private val libs = versionCatalogs.named("libs")
+private val androidCompileSdk = libs.findVersion("android-compileSdk").get().requiredVersion.toInt()
+private val androidMinSdk = libs.findVersion("android-minSdk").get().requiredVersion.toInt()
 
 kotlin {
     @Suppress("UnstableApiUsage")
     androidLibrary {
-        compileSdk = 36
-        minSdk = 24
+        compileSdk = androidCompileSdk
+        minSdk = androidMinSdk
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_11)
@@ -41,16 +43,11 @@ kotlin {
         browser()
     }
 
-    listOf(
-        iosArm64(),
-        iosSimulatorArm64()
-    ).forEach { iosTarget ->
-    }
+    iosArm64()
+    iosSimulatorArm64()
 
     compilerOptions {
         freeCompilerArgs.addAll(
-            "-Xcontext-parameters",
-            "-Xexplicit-backing-fields",
             "-Xexpect-actual-classes",
         )
     }

--- a/docs/template-migrations/2026-07-13.1-directory-grouped-snapshot-goldens.md
+++ b/docs/template-migrations/2026-07-13.1-directory-grouped-snapshot-goldens.md
@@ -67,6 +67,6 @@ rename one.
 Green, with goldens under `snapshots/images/<package>/<dirs>/<PreviewFunctionName>.png`.
 
 Because the verifier is now hand-written, confirm it can actually fail: corrupt a golden, re-run
-`verifyPaparazzi`, and check it reports `Images differ (by N%, tolerance 1.0000%)` and writes the delta
+`verifyPaparazzi`, and check it reports `Images differ (by N%, tolerance 0.0100%)` and writes the delta
 and actual images under `build/paparazzi/failures/`. Then restore the golden and re-verify green. A
 custom verifier that cannot fail is worse than long filenames.

--- a/docs/template-migrations/2026-07-15-snapshot-handler-reporting.md
+++ b/docs/template-migrations/2026-07-15-snapshot-handler-reporting.md
@@ -1,0 +1,40 @@
+# Snapshot handler plain-test safety
+
+The directory-grouped Paparazzi handler now keeps its three execution modes distinct:
+
+- `recordPaparazzi` writes committed goldens;
+- `verifyPaparazzi` compares against committed goldens and fails on unacceptable differences;
+- a plain host-test run writes a report artifact under `build/paparazzi/` without changing goldens.
+
+Previously, the plain-test path called the record implementation and could silently overwrite a
+committed golden when UI changed. The failure message also displayed Paparazzi's default `0.01%`
+threshold as `1%`, although the comparison itself used the correct upstream units.
+
+## Detection
+
+A project is affected if a client module's `DirectorySnapshotHandler.kt` has an `else` branch that
+calls `record(golden, image)`, or formats the configured tolerance as
+`maxPercentDifference * 100`.
+
+## Migration
+
+1. Replace `DirectorySnapshotHandler.kt` in every feature client module with the current template
+   version from
+   `feature/core/client/src/androidHostTest/kotlin/platform/snapshot/DirectorySnapshotHandler.kt`.
+2. Copy `DirectorySnapshotHandlerTest.kt` from the same template directory into every module that
+   owns a copy of the handler, or move the handler and its tests into shared test infrastructure.
+3. Ensure all `verifyPaparazzi` and `recordPaparazzi` commands use
+   `--no-configuration-cache`.
+
+## Verification
+
+Run the plain host test and confirm it leaves the working tree clean, then run snapshot verification:
+
+```bash
+./gradlew :feature:<name>:client:testAndroidHostTest --no-configuration-cache
+git diff --exit-code
+./gradlew :feature:<name>:client:verifyPaparazzi --no-configuration-cache
+```
+
+The handler unit tests must pass, and an intentional snapshot difference should report a default
+tolerance of `0.0100%`.

--- a/feature/core/api/build.gradle.kts
+++ b/feature/core/api/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("ukpt.kmp-library")
-    alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.kotlinKsp)
 }
 

--- a/feature/core/client/build.gradle.kts
+++ b/feature/core/client/build.gradle.kts
@@ -1,7 +1,6 @@
 plugins {
     id("ukpt.compose-library")
     alias(libs.plugins.kotlinKsp)
-    alias(libs.plugins.kotlinSerialization)
     alias(libs.plugins.paparazzi)
 }
 

--- a/feature/core/client/src/androidHostTest/kotlin/platform/snapshot/DirectorySnapshotHandler.kt
+++ b/feature/core/client/src/androidHostTest/kotlin/platform/snapshot/DirectorySnapshotHandler.kt
@@ -19,10 +19,12 @@ import kotlin.math.max
  * `feature/campaigns/ui/CampaignManagementEmptyRolesPreview`. This handler resolves that against the
  * module's `snapshots/images/` directory and appends `.png`.
  *
- * Why a custom handler: the stock `HtmlReportWriter` (record) and `SnapshotVerifier` (verify) both
+ * Why a custom handler: the stock `HtmlReportWriter` (report/record) and `SnapshotVerifier` (verify) both
  * compute the golden path via `Snapshot.toFileName`, which only joins with `_` (no directories) and
  * rejects `/`. So neither can produce a nested layout. This mirrors their behaviour otherwise:
  *
+ * - **report** (a plain test run): writes the rendered frame under `build/paparazzi/` without
+ *   changing the committed golden.
  * - **record** (`paparazzi.test.record=true`): writes the rendered frame to the golden path,
  *   creating parent directories as needed.
  * - **verify** (`paparazzi.test.verify=true`): compares the rendered frame against the committed
@@ -33,8 +35,9 @@ import kotlin.math.max
  *   paths.
  *
  * The system properties consumed here are exactly the ones the Paparazzi gradle plugin sets for the
- * test task (`paparazzi.snapshot.dir`, `paparazzi.failures.dir`, `paparazzi.test.record`,
- * `paparazzi.test.verify`, `app.cash.paparazzi.maxPercentDifferenceDefault`).
+ * test task (`paparazzi.snapshot.dir`, `paparazzi.report.dir`, `paparazzi.failures.dir`,
+ * `paparazzi.test.record`, `paparazzi.test.verify`,
+ * `app.cash.paparazzi.maxPercentDifferenceDefault`).
  */
 internal class DirectorySnapshotHandler : SnapshotHandler {
 
@@ -54,6 +57,10 @@ internal class DirectorySnapshotHandler : SnapshotHandler {
     private val failuresDir: File?
         get() = System.getProperty("paparazzi.failures.dir")?.let { File(it).apply { mkdirs() } }
 
+    private val reportImagesDir: File?
+        get() = System.getProperty("paparazzi.report.dir")
+            ?.let { File(it, "directory-snapshots").apply { mkdirs() } }
+
     override fun newFrameHandler(
         snapshot: Snapshot,
         frameCount: Int,
@@ -70,9 +77,9 @@ internal class DirectorySnapshotHandler : SnapshotHandler {
                 } else if (isVerifying) {
                     verify(golden, image)
                 } else {
-                    // No explicit mode (e.g. a plain `test` run): behave like record so goldens can
-                    // be produced, matching Paparazzi's own default-to-report behaviour of not failing.
-                    record(golden, image)
+                    // Match Paparazzi's default mode: render a report artifact, but never mutate
+                    // source-controlled goldens unless the explicit record task is running.
+                    report(relativePath, image)
                 }
             }
 
@@ -87,13 +94,19 @@ internal class DirectorySnapshotHandler : SnapshotHandler {
         ImageIO.write(image, "PNG", golden)
     }
 
+    private fun report(relativePath: String, image: BufferedImage) {
+        val output = reportImagesDir?.resolve("$relativePath.png") ?: return
+        output.parentFile?.mkdirs()
+        ImageIO.write(image, "PNG", output)
+    }
+
     private fun verify(golden: File, image: BufferedImage) {
         val expectedPath = golden.absolutePath
         if (!golden.exists()) {
             writeFailureArtifacts(golden, actual = image, delta = null)
             throw AssertionError(
                 "Missing golden image: no snapshot recorded at $expectedPath\n" +
-                    "Record it with: ./gradlew ${':'}${golden.parentFile?.name}… recordPaparazzi (or the module's recordPaparazzi task).",
+                    "Record it with the module's recordPaparazzi task and --no-configuration-cache.",
             )
         }
 
@@ -111,7 +124,7 @@ internal class DirectorySnapshotHandler : SnapshotHandler {
 
         val error: String? = when {
             percentDifference > maxPercentDifference ->
-                "Images differ (by %.4f%%, tolerance %.4f%%)".format(percentDifference, maxPercentDifference * 100)
+                "Images differ (by %.4f%%, tolerance %.4f%%)".format(percentDifference, maxPercentDifference)
             abs(goldenW - actualW) >= 2 ->
                 "Widths differ too much: ${goldenW}x$goldenH (golden) vs ${actualW}x$actualH (actual)"
             abs(goldenH - actualH) >= 2 ->

--- a/feature/core/client/src/androidHostTest/kotlin/platform/snapshot/DirectorySnapshotHandlerTest.kt
+++ b/feature/core/client/src/androidHostTest/kotlin/platform/snapshot/DirectorySnapshotHandlerTest.kt
@@ -1,0 +1,107 @@
+package platform.snapshot
+
+import app.cash.paparazzi.Snapshot
+import app.cash.paparazzi.TestName
+import java.awt.image.BufferedImage
+import java.awt.image.BufferedImage.TYPE_INT_ARGB
+import java.io.File
+import java.nio.file.Files
+import java.util.Date
+import javax.imageio.ImageIO
+import org.junit.After
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class DirectorySnapshotHandlerTest {
+
+    private lateinit var root: File
+    private lateinit var snapshots: File
+    private lateinit var reports: File
+    private lateinit var failures: File
+    private val originalProperties = mutableMapOf<String, String?>()
+
+    @Before
+    fun setUp() {
+        root = Files.createTempDirectory("directory-snapshot-handler").toFile()
+        snapshots = File(root, "snapshots")
+        reports = File(root, "reports")
+        failures = File(root, "failures")
+
+        setProperty("paparazzi.snapshot.dir", snapshots.absolutePath)
+        setProperty("paparazzi.report.dir", reports.absolutePath)
+        setProperty("paparazzi.failures.dir", failures.absolutePath)
+        setProperty("paparazzi.test.record", "false")
+        setProperty("paparazzi.test.verify", "false")
+        setProperty("app.cash.paparazzi.maxPercentDifferenceDefault", null)
+    }
+
+    @After
+    fun tearDown() {
+        originalProperties.forEach { (name, value) ->
+            if (value == null) System.clearProperty(name) else System.setProperty(name, value)
+        }
+        root.deleteRecursively()
+    }
+
+    @Test
+    fun plainTestWritesReportWithoutChangingGolden() {
+        render(solidImage(0xFF000000.toInt()))
+
+        assertFalse(goldenFile().exists())
+        assertTrue(File(reports, "directory-snapshots/example/Preview.png").exists())
+    }
+
+    @Test
+    fun recordWritesGolden() {
+        setProperty("paparazzi.test.record", "true")
+
+        render(solidImage(0xFF000000.toInt()))
+
+        assertTrue(goldenFile().exists())
+    }
+
+    @Test
+    fun verifyUsesPaparazziPercentageUnits() {
+        goldenFile().apply {
+            requireNotNull(parentFile).mkdirs()
+            ImageIO.write(solidImage(0xFF000000.toInt()), "PNG", this)
+        }
+        setProperty("paparazzi.test.verify", "true")
+        setProperty("app.cash.paparazzi.maxPercentDifferenceDefault", "40.0")
+        render(solidImage(0xFFFF0000.toInt()))
+
+        setProperty("app.cash.paparazzi.maxPercentDifferenceDefault", "30.0")
+
+        val failure = runCatching { render(solidImage(0xFFFF0000.toInt())) }.exceptionOrNull()
+
+        assertTrue(failure is AssertionError)
+        assertTrue(failure?.message.orEmpty().contains("tolerance 30.0000%"))
+    }
+
+    private fun render(image: BufferedImage) {
+        DirectorySnapshotHandler()
+            .newFrameHandler(
+                snapshot = Snapshot(
+                    name = "example/Preview",
+                    testName = TestName("platform.snapshot", "HandlerTest", "snapshot"),
+                    timestamp = Date(0),
+                ),
+                frameCount = 1,
+                fps = -1,
+            )
+            .use { it.handle(image) }
+    }
+
+    private fun goldenFile(): File = File(snapshots, "images/example/Preview.png")
+
+    private fun solidImage(argb: Int): BufferedImage = BufferedImage(1, 1, TYPE_INT_ARGB).apply {
+        setRGB(0, 0, argb)
+    }
+
+    private fun setProperty(name: String, value: String?) {
+        if (name !in originalProperties) originalProperties[name] = System.getProperty(name)
+        if (value == null) System.clearProperty(name) else System.setProperty(name, value)
+    }
+}

--- a/feature/core/server/build.gradle.kts
+++ b/feature/core/server/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
     id("ukpt.jvm-library")
-    alias(libs.plugins.kotlinSerialization)
 }
 
 dependencies {

--- a/platform/common/architecture/build.gradle.kts
+++ b/platform/common/architecture/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    alias(libs.plugins.kotlinJvm)
+    id("ukpt.jvm-base")
     // Adds the architectureTest source set and the standalone verifyArchitecture /
     // updateArchitectureDocumentation tasks (plain `test` runs nothing here). The test classes
     // themselves are generated into build/generated/ from the definition below — none are checked


### PR DESCRIPTION
## Summary
- enforce Java 11 bytecode consistently through shared JVM conventions
- centralise Android SDK values and remove redundant plugin/compiler configuration
- prevent plain Paparazzi host tests from overwriting committed goldens
- add regression coverage and downstream migration guidance

## Verification
- six-target Gradle compile sweep
- :platform:common:architecture:verifyArchitecture
- :feature:core:client:testAndroidHostTest
- :feature:core:client:verifyPaparazzi
- javap confirms JVM class major version 55