### PR TITLE
Add template maintenance tooling

### DIFF
--- a/.agents/skills/ukpt-new-project/SKILL.md
+++ b/.agents/skills/ukpt-new-project/SKILL.md
@@ -42,10 +42,22 @@ renamed, which is what `ukpt-template-update` needs later. Do not skip it.
 Ask the user for the project name and base package if not given. Rename by semantic scope; never
 run an unrestricted repository-wide replacement for `ukpt` or `Ukpt`.
 
+Generate the deterministic rename inventory before editing. Read the `REPLACE`, `REVIEW`, and
+`KEEP` sections in `build/reports/ukpt/project-rename-plan.txt` and resolve the worked-core-feature
+choice in `REVIEW` with the user:
+
+```
+./gradlew planProjectRename \
+  -Pukpt.newProjectName=<project-name> \
+  -Pukpt.newProjectPackage=<package> \
+  -Pukpt.newProjectTypePrefix=<ProjectName>
+```
+
 | Template value | Becomes | Where |
 | --- | --- | --- |
 | `com.isaacudy.ukpt` | `<package>` | app shells (packages, directories, `applicationId`), and `PRODUCT_BUNDLE_IDENTIFIER` in `app/client/ios/iosApp.xcodeproj/project.pbxproj` |
 | `ukpt` (lowercase word) | `<project-name>` | app/window titles, `rootProject.name`, project-facing README copy |
+| `ukpt` (identifier prefix) | lower-camel `<ProjectName>` | code identifiers such as `ukptClientDependencies`; rename only with their declaring feature |
 | `Ukpt` type prefix | `<ProjectName>` | `:feature:core` example types, app entry points |
 | `feature.ukpt` | `feature.<first-feature>` or leave | `:feature:core` example (see note) |
 
@@ -65,6 +77,9 @@ run an unrestricted repository-wide replacement for `ukpt` or `Ukpt`.
   `ukpt-template-update` syncs it.
 - After renaming, search separately for the old package, lowercase name, and type prefix. Review
   every remaining match against the allowlist instead of assuming every match is stale.
+- Re-run `planProjectRename` with the same properties plus
+  `-Pukpt.renameFailOnReplace=true`. It must report zero `REPLACE` occurrences; `REVIEW` and `KEEP`
+  entries may remain by design.
 
 ## 4. Write the marker
 
@@ -99,6 +114,7 @@ Run the full matrix before the first commit:
           :app:client:common:compileKotlinIosSimulatorArm64 :app:server:compileKotlin
 ./gradlew :platform:common:architecture:verifyArchitecture
 ./gradlew :feature:core:client:verifyPaparazzi --no-configuration-cache
+./gradlew validateTemplate
 bash .agents/skills/ukpt-verify-web/run-bundle-check.sh
 
 # iOS: the Xcode project must still build after the bundle id is renamed.

--- a/.agents/skills/ukpt-template-update/SKILL.md
+++ b/.agents/skills/ukpt-template-update/SKILL.md
@@ -122,6 +122,7 @@ The full matrix, from UKPT.md:
           :app:client:common:compileKotlinIosSimulatorArm64 :app:server:compileKotlin
 ./gradlew :platform:common:architecture:verifyArchitecture
 ./gradlew :feature:<each>:client:verifyPaparazzi --no-configuration-cache
+./gradlew validateTemplate
 bash .agents/skills/ukpt-verify-web/run-bundle-check.sh
 ```
 

--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-07-15.1"
+  "templateVersion": "2026-07-15.2"
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,20 @@ To start a real project from the template, use the
 identity, sets up the repository and submodules, and writes the `.ukpt/template.json` marker that
 later template updates depend on.
 
+Before renaming, it generates a classified, non-mutating inventory so UKPT-owned identifiers are
+not caught in a global replacement:
+
+```bash
+./gradlew planProjectRename \
+  -Pukpt.newProjectName=my-project \
+  -Pukpt.newProjectPackage=com.example.myproject \
+  -Pukpt.newProjectTypePrefix=MyProject
+```
+
+The report is written to `build/reports/ukpt/project-rename-plan.txt` with `REPLACE`, `REVIEW`, and
+`KEEP` sections. Re-run with `-Pukpt.renameFailOnReplace=true` after renaming to fail if required
+project-identity replacements remain.
+
 ## Architecture
 
 **Read the [architecture README](platform/common/architecture/README.md)** for an overview of the
@@ -159,6 +173,14 @@ one is discovered and snapshotted. Goldens are grouped by package, for example
 The Gradle configuration cache is on. Two task families are incompatible with it and need
 `--no-configuration-cache`: the wasm browser and webpack tasks, and Paparazzi record/verify.
 Everything else, including the full compile sweep, is cache-clean.
+
+Template maintainers can validate the marker, migration documents, agent imports, shared skill
+metadata, and Claude compatibility links with:
+
+```bash
+./gradlew validateTemplate
+./gradlew -p build-logic test
+```
 
 ## Template updates
 

--- a/UKPT.md
+++ b/UKPT.md
@@ -12,6 +12,10 @@ This file holds operational guidance (commands, toolchain, submodules) and point
 
 Downstream projects update from this template with the `ukpt-template-update` skill, driven by `.ukpt/template.json` and [`docs/template-migrations/`](./docs/template-migrations/README.md). When a change affects code that only exists downstream — a convention change, an architecture rule added/renamed/tightened, a structural change — bump `templateVersion` in `.ukpt/template.json` and add a migration entry in the same commit (see the migrations README for the format). Version bumps and template-owned file changes don't need an entry.
 
+Before committing a template change, run `./gradlew validateTemplate`. It checks the marker and
+migration ordering/sections, shared agent guidance, Codex skill metadata, and Claude compatibility
+links. The validator and rename-planner unit tests run with `./gradlew -p build-logic test`.
+
 ## Architecture
 
 Follow the rules in [`platform/common/architecture/README.md`](./platform/common/architecture/README.md), enforced by Konsist tests. Orientation:
@@ -66,6 +70,9 @@ The common module's Android / JVM / wasm targets compile transitively via the pe
 
 ## Testing
 
+- **Template integrity**: `./gradlew validateTemplate` — validates template metadata, migrations,
+  shared agent guidance, and skills. `./gradlew -p build-logic test` runs the validator and safe
+  project-rename planner's unit tests.
 - **Architecture rules**: `./gradlew :platform:common:architecture:verifyArchitecture` — a standalone task that always re-executes (no `--rerun-tasks` needed; the module's plain `test` task runs nothing — the test classes are plugin-generated from the `UkptArchitecture` definition, not checked in). The suite reports **one nested test per rule** (`<Layer> › <Construct> › <rule>`), so a failure names the exact rule. After changing a rule or an examples file, regenerate the generated docs (README + `docs/`): `./gradlew :platform:common:architecture:updateArchitectureDocumentation`.
 - **UI snapshots** are preview-driven: every `@Preview` composable is discovered by `PreviewSnapshotTest` and snapshotted with Paparazzi (`UiLayer.Composable.screenContentPreview` requires a `@Preview` per ScreenContent). Record then verify goldens, per client module:
 ```

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -4,8 +4,16 @@ plugins {
 
 dependencies {
     implementation(libs.kotlin.gradlePlugin)
+    implementation(libs.kotlinx.serialization)
     implementation(libs.kotlinx.serialization.gradlePlugin)
     implementation(libs.android.gradlePlugin)
     implementation(libs.compose.gradlePlugin)
     implementation(libs.compose.compiler.gradlePlugin)
+
+    testImplementation(libs.kotlin.test)
+    testImplementation(libs.junit.jupiter)
+}
+
+tasks.test {
+    useJUnitPlatform()
 }

--- a/build-logic/src/main/kotlin/ukpt.template-maintenance.gradle.kts
+++ b/build-logic/src/main/kotlin/ukpt.template-maintenance.gradle.kts
@@ -1,0 +1,21 @@
+import ukpt.template.PlanProjectRenameTask
+import ukpt.template.ValidateTemplateTask
+
+tasks.register<ValidateTemplateTask>("validateTemplate") {
+    group = "verification"
+    description = "Validates UKPT's marker, migrations, agent guidance, and shared skills."
+    repositoryDirectory.set(layout.projectDirectory)
+}
+
+tasks.register<PlanProjectRenameTask>("planProjectRename") {
+    group = "ukpt"
+    description = "Writes a safe, classified plan for renaming a fresh UKPT project."
+    repositoryDirectory.set(layout.projectDirectory)
+    projectName.convention(providers.gradleProperty("ukpt.newProjectName"))
+    packageName.convention(providers.gradleProperty("ukpt.newProjectPackage"))
+    typePrefix.convention(providers.gradleProperty("ukpt.newProjectTypePrefix"))
+    failOnReplace.convention(
+        providers.gradleProperty("ukpt.renameFailOnReplace").map(String::toBoolean).orElse(false),
+    )
+    reportFile.set(layout.buildDirectory.file("reports/ukpt/project-rename-plan.txt"))
+}

--- a/build-logic/src/main/kotlin/ukpt/template/ProjectRenamePlanner.kt
+++ b/build-logic/src/main/kotlin/ukpt/template/ProjectRenamePlanner.kt
@@ -1,0 +1,248 @@
+package ukpt.template
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+import kotlin.io.path.invariantSeparatorsPathString
+import kotlin.io.path.name
+import kotlin.io.path.readText
+
+data class ProjectRenameRequest(
+    val projectName: String,
+    val packageName: String,
+    val typePrefix: String,
+)
+
+enum class RenameDisposition {
+    REPLACE,
+    REVIEW,
+    KEEP,
+}
+
+data class RenameOccurrence(
+    val path: String,
+    val line: Int,
+    val column: Int,
+    val source: String,
+    val replacement: String,
+    val disposition: RenameDisposition,
+    val reason: String,
+)
+
+data class DirectoryMove(
+    val source: String,
+    val destination: String,
+)
+
+data class ProjectRenamePlan(
+    val request: ProjectRenameRequest,
+    val occurrences: List<RenameOccurrence>,
+    val directoryMoves: List<DirectoryMove>,
+) {
+    fun render(): String = buildString {
+        appendLine("UKPT project rename plan")
+        appendLine("project name: ${request.projectName}")
+        appendLine("package:      ${request.packageName}")
+        appendLine("type prefix:  ${request.typePrefix}")
+        appendLine()
+        appendLine("Directory moves")
+        if (directoryMoves.isEmpty()) appendLine("  (none)")
+        directoryMoves.forEach { appendLine("  ${it.source} -> ${it.destination}") }
+        appendLine()
+        RenameDisposition.entries.forEach { disposition ->
+            val matching = occurrences.filter { it.disposition == disposition }
+            appendLine("$disposition (${matching.size})")
+            if (matching.isEmpty()) appendLine("  (none)")
+            if (disposition == RenameDisposition.KEEP) {
+                matching.groupingBy(RenameOccurrence::path).eachCount().forEach { (path, count) ->
+                    appendLine("  $path ($count protected occurrence(s))")
+                }
+            } else {
+                matching.forEach { occurrence ->
+                    appendLine(
+                        "  ${occurrence.path}:${occurrence.line}:${occurrence.column} " +
+                            "'${occurrence.source}' -> '${occurrence.replacement}' — ${occurrence.reason}",
+                    )
+                }
+            }
+            appendLine()
+        }
+    }
+}
+
+object ProjectRenamePlanner {
+    private val projectNamePattern = Regex("^[a-z][a-z0-9-]*$")
+    private val packagePattern = Regex("^[a-z][a-z0-9_]*(?:\\.[a-z][a-z0-9_]*)+$")
+    private val typePrefixPattern = Regex("^[A-Z][A-Za-z0-9]*$")
+    private val identityPattern = Regex(
+        "com\\.isaacudy\\.ukpt|feature\\.ukpt|Ukpt(?=[A-Z]|\\b)|ukpt(?=[A-Z]|\\b)",
+    )
+    private val skippedDirectories = setOf(
+        ".git",
+        ".gradle",
+        ".idea",
+        ".kotlin",
+        ".cxx",
+        ".externalNativeBuild",
+        "build",
+        "captures",
+        "node_modules",
+        "embedded-enro",
+        "embedded-udytils",
+    )
+    private val protectedPrefixes = listOf(
+        ".agents/",
+        ".claude/",
+        ".ukpt/",
+        "build-logic/",
+        "docs/template-migrations/",
+        "platform/common/architecture/",
+    )
+    private val workedCoreIdentifiers = setOf(
+        "UkptDestination",
+        "ukptClientDependencies",
+    )
+
+    fun validate(request: ProjectRenameRequest): List<String> = buildList {
+        if (!projectNamePattern.matches(request.projectName)) {
+            add("project name must be a lowercase slug such as my-project")
+        }
+        if (!packagePattern.matches(request.packageName)) {
+            add("package must contain at least two lowercase Java/Kotlin segments")
+        }
+        if (!typePrefixPattern.matches(request.typePrefix)) {
+            add("type prefix must be a PascalCase identifier such as MyProject")
+        }
+    }
+
+    fun plan(repository: Path, request: ProjectRenameRequest): ProjectRenamePlan {
+        val validationErrors = validate(request)
+        require(validationErrors.isEmpty()) { validationErrors.joinToString("; ") }
+
+        val occurrences = mutableListOf<RenameOccurrence>()
+        val directoryMoves = mutableListOf<DirectoryMove>()
+        Files.walkFileTree(repository, object : SimpleFileVisitor<Path>() {
+            override fun preVisitDirectory(directory: Path, attributes: BasicFileAttributes): FileVisitResult {
+                if (directory != repository && directory.name in skippedDirectories) {
+                    return FileVisitResult.SKIP_SUBTREE
+                }
+                val relativePath = repository.relativize(directory).invariantSeparatorsPathString
+                if (relativePath.endsWith("/com/isaacudy/ukpt")) {
+                    val parent = relativePath.removeSuffix("/com/isaacudy/ukpt")
+                    directoryMoves += DirectoryMove(
+                        source = relativePath,
+                        destination = "$parent/${request.packageName.replace('.', '/')}",
+                    )
+                }
+                return FileVisitResult.CONTINUE
+            }
+
+            override fun visitFile(file: Path, attributes: BasicFileAttributes): FileVisitResult {
+                if (attributes.isRegularFile && attributes.size() <= 1_048_576 && !Files.isSymbolicLink(file)) {
+                    collectOccurrences(repository, file, request, occurrences)
+                }
+                return FileVisitResult.CONTINUE
+            }
+        })
+
+        return ProjectRenamePlan(
+            request = request,
+            occurrences = occurrences.sortedWith(
+                compareBy<RenameOccurrence>({ it.disposition }, { it.path }, { it.line }, { it.column }),
+            ),
+            directoryMoves = directoryMoves.distinct().sortedBy(DirectoryMove::source),
+        )
+    }
+
+    private fun collectOccurrences(
+        repository: Path,
+        file: Path,
+        request: ProjectRenameRequest,
+        destination: MutableList<RenameOccurrence>,
+    ) {
+        val contents = try {
+            file.readText(StandardCharsets.UTF_8)
+        } catch (_: Exception) {
+            return
+        }
+        if ('\u0000' in contents) return
+
+        val relativePath = repository.relativize(file).invariantSeparatorsPathString
+        contents.lineSequence().forEachIndexed { lineIndex, line ->
+            identityPattern.findAll(line).forEach { match ->
+                val source = match.value
+                val (disposition, reason) = classify(relativePath, line, match.range.first, source)
+                destination += RenameOccurrence(
+                    path = relativePath,
+                    line = lineIndex + 1,
+                    column = match.range.first + 1,
+                    source = source,
+                    replacement = replacementFor(source, line, match.range.first, request),
+                    disposition = disposition,
+                    reason = reason,
+                )
+            }
+        }
+    }
+
+    private fun classify(
+        path: String,
+        line: String,
+        column: Int,
+        source: String,
+    ): Pair<RenameDisposition, String> {
+        if (path == "UKPT.md" || protectedPrefixes.any(path::startsWith)) {
+            return RenameDisposition.KEEP to "template identity is protected"
+        }
+        if (source == "ukpt" && line.substring(column).startsWith("ukpt.")) {
+            return RenameDisposition.KEEP to "UKPT Gradle property and convention-plugin keys are stable"
+        }
+        if (source == "feature.ukpt") {
+            return RenameDisposition.REVIEW to "rename only if the worked core feature is rebranded"
+        }
+        if (identifierAt(line, column) in workedCoreIdentifiers) {
+            return RenameDisposition.REVIEW to "rename only if the worked core feature is rebranded"
+        }
+        if (path == "README.md") {
+            return RenameDisposition.REVIEW to "project may keep or replace the worked template example"
+        }
+        if (source == "com.isaacudy.ukpt") {
+            return RenameDisposition.REPLACE to "application package reference"
+        }
+        if (path.startsWith("feature/core/")) {
+            return RenameDisposition.REVIEW to "project may keep or replace the worked template example"
+        }
+        if (path.startsWith("app/") || path == "gradle.properties") {
+            return RenameDisposition.REPLACE to "project identity in an app-owned file"
+        }
+        return RenameDisposition.REVIEW to "outside the deterministic app allowlist"
+    }
+
+    private fun replacementFor(
+        source: String,
+        line: String,
+        column: Int,
+        request: ProjectRenameRequest,
+    ): String = when (source) {
+        "com.isaacudy.ukpt" -> request.packageName
+        "feature.ukpt" -> "<feature package or keep feature.ukpt>"
+        "Ukpt" -> request.typePrefix
+        "ukpt" -> if (identifierAt(line, column).length > source.length) {
+            request.typePrefix.replaceFirstChar(Char::lowercaseChar)
+        } else {
+            request.projectName
+        }
+        else -> error("Unhandled identity token: $source")
+    }
+
+    private fun identifierAt(line: String, column: Int): String {
+        var start = column
+        while (start > 0 && Character.isJavaIdentifierPart(line[start - 1])) start--
+        var end = column
+        while (end < line.length && Character.isJavaIdentifierPart(line[end])) end++
+        return line.substring(start, end)
+    }
+}

--- a/build-logic/src/main/kotlin/ukpt/template/TemplateMaintenanceTasks.kt
+++ b/build-logic/src/main/kotlin/ukpt/template/TemplateMaintenanceTasks.kt
@@ -1,0 +1,80 @@
+package ukpt.template
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.GradleException
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.UntrackedTask
+
+@UntrackedTask(because = "Validation should inspect the current repository on every run")
+abstract class ValidateTemplateTask : DefaultTask() {
+    @get:Internal
+    abstract val repositoryDirectory: DirectoryProperty
+
+    @TaskAction
+    fun validateTemplate() {
+        val issues = TemplateRepositoryValidator.validate(repositoryDirectory.get().asFile.toPath())
+        if (issues.isNotEmpty()) {
+            val report = issues.joinToString(separator = "\n") { "- ${it.path}: ${it.message}" }
+            throw GradleException("UKPT template validation failed:\n$report")
+        }
+        logger.lifecycle("UKPT template validation passed")
+    }
+}
+
+@UntrackedTask(because = "The plan should inspect the current repository on every run")
+abstract class PlanProjectRenameTask : DefaultTask() {
+    @get:Internal
+    abstract val repositoryDirectory: DirectoryProperty
+
+    @get:Input
+    abstract val projectName: Property<String>
+
+    @get:Input
+    abstract val packageName: Property<String>
+
+    @get:Input
+    abstract val typePrefix: Property<String>
+
+    @get:Input
+    abstract val failOnReplace: Property<Boolean>
+
+    @get:OutputFile
+    abstract val reportFile: RegularFileProperty
+
+    @TaskAction
+    fun planRename() {
+        val request = ProjectRenameRequest(
+            projectName = projectName.get(),
+            packageName = packageName.get(),
+            typePrefix = typePrefix.get(),
+        )
+        val errors = ProjectRenamePlanner.validate(request)
+        if (errors.isNotEmpty()) {
+            throw GradleException(errors.joinToString(prefix = "Invalid rename request:\n- ", separator = "\n- "))
+        }
+
+        val plan = ProjectRenamePlanner.plan(repositoryDirectory.get().asFile.toPath(), request)
+        val report = reportFile.get().asFile
+        report.parentFile.mkdirs()
+        report.writeText(plan.render())
+
+        val counts = RenameDisposition.entries.joinToString { disposition ->
+            "$disposition=${plan.occurrences.count { it.disposition == disposition }}"
+        }
+        logger.lifecycle("Project rename plan written to ${report.absolutePath} ($counts)")
+
+        val remainingReplacements = plan.occurrences.count { it.disposition == RenameDisposition.REPLACE }
+        if (failOnReplace.get() && remainingReplacements > 0) {
+            throw GradleException(
+                "$remainingReplacements required project-identity replacement(s) remain; " +
+                    "review ${report.absolutePath}",
+            )
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/ukpt/template/TemplateRepositoryValidator.kt
+++ b/build-logic/src/main/kotlin/ukpt/template/TemplateRepositoryValidator.kt
@@ -1,0 +1,255 @@
+package ukpt.template
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.LocalDate
+import java.time.format.DateTimeParseException
+import java.util.stream.Collectors
+import kotlin.io.path.name
+import kotlin.io.path.readText
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+data class TemplateValidationIssue(
+    val path: String,
+    val message: String,
+)
+
+data class TemplateVersion(
+    val date: LocalDate,
+    val revision: Int = 0,
+) : Comparable<TemplateVersion> {
+    override fun compareTo(other: TemplateVersion): Int =
+        compareValuesBy(this, other, TemplateVersion::date, TemplateVersion::revision)
+
+    companion object {
+        private val pattern = Regex("""^(\d{4}-\d{2}-\d{2})(?:\.([1-9]\d*))?$""")
+
+        fun parse(value: String): TemplateVersion {
+            val match = pattern.matchEntire(value)
+                ?: throw IllegalArgumentException(
+                    "expected YYYY-MM-DD or YYYY-MM-DD.N (with N greater than zero)",
+                )
+            val date = try {
+                LocalDate.parse(match.groupValues[1])
+            } catch (exception: DateTimeParseException) {
+                throw IllegalArgumentException("invalid calendar date", exception)
+            }
+            val revision = match.groupValues[2].takeIf(String::isNotEmpty)?.toInt() ?: 0
+            return TemplateVersion(date, revision)
+        }
+    }
+}
+
+object TemplateRepositoryValidator {
+    private val migrationName =
+        Regex("""^(\d{4}-\d{2}-\d{2}(?:\.[1-9]\d*)?)-[a-z0-9]+(?:-[a-z0-9]+)*\.md$""")
+    private val requiredMigrationHeadings = listOf("## Detection", "## Migration", "## Verification")
+
+    fun validate(repository: Path): List<TemplateValidationIssue> = buildList {
+        val templateVersion = validateMarker(repository, this)
+        validateMigrations(repository, templateVersion, this)
+        validateAgentGuidance(repository, this)
+        validateSkills(repository, this)
+    }
+
+    private fun validateMarker(
+        repository: Path,
+        issues: MutableList<TemplateValidationIssue>,
+    ): TemplateVersion? {
+        val relativePath = ".ukpt/template.json"
+        val marker = repository.resolve(relativePath)
+        if (!Files.isRegularFile(marker)) {
+            issues += TemplateValidationIssue(relativePath, "missing template marker")
+            return null
+        }
+
+        val version = try {
+            Json.parseToJsonElement(marker.readText())
+                .jsonObject["templateVersion"]
+                ?.jsonPrimitive
+                ?.contentOrNull
+        } catch (exception: Exception) {
+            issues += TemplateValidationIssue(relativePath, "invalid JSON: ${exception.message}")
+            return null
+        }
+        if (version == null) {
+            issues += TemplateValidationIssue(relativePath, "templateVersion must be a string")
+            return null
+        }
+        return try {
+            TemplateVersion.parse(version)
+        } catch (exception: IllegalArgumentException) {
+            issues += TemplateValidationIssue(relativePath, "invalid templateVersion '$version': ${exception.message}")
+            null
+        }
+    }
+
+    private fun validateMigrations(
+        repository: Path,
+        currentVersion: TemplateVersion?,
+        issues: MutableList<TemplateValidationIssue>,
+    ) {
+        val migrationsDirectory = repository.resolve("docs/template-migrations")
+        if (!Files.isDirectory(migrationsDirectory)) {
+            issues += TemplateValidationIssue("docs/template-migrations", "missing migrations directory")
+            return
+        }
+
+        val migrations = Files.list(migrationsDirectory).use { paths ->
+            paths
+                .filter { Files.isRegularFile(it) && it.name.endsWith(".md") && it.name != "README.md" }
+                .sorted()
+                .collect(Collectors.toList())
+        }
+        migrations.forEach { migration ->
+            val relativePath = repository.relativize(migration).toString()
+            val match = migrationName.matchEntire(migration.name)
+            if (match == null) {
+                issues += TemplateValidationIssue(
+                    relativePath,
+                    "filename must be <templateVersion>-<lowercase-slug>.md",
+                )
+                return@forEach
+            }
+
+            val migrationVersion = try {
+                TemplateVersion.parse(match.groupValues[1])
+            } catch (exception: IllegalArgumentException) {
+                issues += TemplateValidationIssue(relativePath, "invalid version: ${exception.message}")
+                return@forEach
+            }
+            if (currentVersion != null && migrationVersion > currentVersion) {
+                issues += TemplateValidationIssue(relativePath, "migration is newer than templateVersion")
+            }
+
+            val contents = migration.readText()
+            requiredMigrationHeadings.forEach { heading ->
+                if (!Regex("(?m)^${Regex.escape(heading)}\\s*$").containsMatchIn(contents)) {
+                    issues += TemplateValidationIssue(relativePath, "missing '$heading' section")
+                }
+            }
+        }
+    }
+
+    private fun validateAgentGuidance(
+        repository: Path,
+        issues: MutableList<TemplateValidationIssue>,
+    ) {
+        val agents = repository.resolve("AGENTS.md")
+        if (!Files.isRegularFile(agents)) {
+            issues += TemplateValidationIssue("AGENTS.md", "missing project agent guidance")
+        } else if (!agents.readText().contains("UKPT.md")) {
+            issues += TemplateValidationIssue("AGENTS.md", "must direct agents to UKPT.md")
+        }
+
+        val claude = repository.resolve("CLAUDE.md")
+        if (!Files.isRegularFile(claude)) {
+            issues += TemplateValidationIssue("CLAUDE.md", "missing Claude compatibility guidance")
+        } else {
+            val imports = claude.readText().lineSequence().map(String::trim).toSet()
+            listOf("@AGENTS.md", "@UKPT.md").forEach { requiredImport ->
+                if (requiredImport !in imports) {
+                    issues += TemplateValidationIssue("CLAUDE.md", "missing '$requiredImport' import")
+                }
+            }
+        }
+    }
+
+    private fun validateSkills(
+        repository: Path,
+        issues: MutableList<TemplateValidationIssue>,
+    ) {
+        val canonicalRoot = repository.resolve(".agents/skills")
+        if (!Files.isDirectory(canonicalRoot)) {
+            issues += TemplateValidationIssue(".agents/skills", "missing canonical skill directory")
+            return
+        }
+        val skillDirectories = Files.list(canonicalRoot).use { paths ->
+            paths
+                .filter { Files.isDirectory(it) && it.name.startsWith("ukpt-") }
+                .sorted()
+                .collect(Collectors.toList())
+        }
+        if (skillDirectories.isEmpty()) {
+            issues += TemplateValidationIssue(".agents/skills", "no ukpt-* skills found")
+        }
+
+        val canonicalNames = skillDirectories.mapTo(mutableSetOf()) { it.name }
+        skillDirectories.forEach { skill -> validateSkill(repository, skill, issues) }
+
+        val claudeRoot = repository.resolve(".claude/skills")
+        canonicalNames.forEach { name ->
+            val relativePath = ".claude/skills/$name"
+            val compatibilityLink = repository.resolve(relativePath)
+            val expectedTarget = Path.of("../../.agents/skills/$name")
+            if (!Files.isSymbolicLink(compatibilityLink)) {
+                issues += TemplateValidationIssue(relativePath, "must be a symbolic link to $expectedTarget")
+            } else if (Files.readSymbolicLink(compatibilityLink) != expectedTarget) {
+                issues += TemplateValidationIssue(
+                    relativePath,
+                    "points to ${Files.readSymbolicLink(compatibilityLink)} instead of $expectedTarget",
+                )
+            }
+        }
+
+        if (Files.isDirectory(claudeRoot)) {
+            Files.list(claudeRoot).use { paths ->
+                paths.filter { it.name.startsWith("ukpt-") && it.name !in canonicalNames }.forEach { extra ->
+                    issues += TemplateValidationIssue(
+                        repository.relativize(extra).toString(),
+                        "has no matching canonical skill under .agents/skills",
+                    )
+                }
+            }
+        }
+    }
+
+    private fun validateSkill(
+        repository: Path,
+        skill: Path,
+        issues: MutableList<TemplateValidationIssue>,
+    ) {
+        val skillName = skill.name
+        val skillFile = skill.resolve("SKILL.md")
+        val skillPath = repository.relativize(skillFile).toString()
+        if (!Files.isRegularFile(skillFile)) {
+            issues += TemplateValidationIssue(skillPath, "missing SKILL.md")
+            return
+        }
+
+        val contents = skillFile.readText()
+        val frontmatter = Regex("""\A---\n(.*?)\n---""", RegexOption.DOT_MATCHES_ALL)
+            .find(contents)
+            ?.groupValues
+            ?.get(1)
+        if (frontmatter == null) {
+            issues += TemplateValidationIssue(skillPath, "missing YAML frontmatter")
+        } else {
+            val keys = frontmatter.lineSequence()
+                .filter { it.isNotBlank() && !it.first().isWhitespace() && ':' in it }
+                .map { it.substringBefore(':') }
+                .toSet()
+            if (keys != setOf("name", "description")) {
+                issues += TemplateValidationIssue(skillPath, "frontmatter keys must be name and description")
+            }
+            val declaredName = Regex("(?m)^name:\\s*([a-z0-9-]+)\\s*$")
+                .find(frontmatter)
+                ?.groupValues
+                ?.get(1)
+            if (declaredName != skillName) {
+                issues += TemplateValidationIssue(skillPath, "name '$declaredName' must match directory '$skillName'")
+            }
+        }
+
+        val metadata = skill.resolve("agents/openai.yaml")
+        val metadataPath = repository.relativize(metadata).toString()
+        if (!Files.isRegularFile(metadata)) {
+            issues += TemplateValidationIssue(metadataPath, "missing Codex UI metadata")
+        } else if (!metadata.readText().contains("\$$skillName")) {
+            issues += TemplateValidationIssue(metadataPath, "default_prompt must mention \$$skillName")
+        }
+    }
+}

--- a/build-logic/src/test/kotlin/ukpt/template/ProjectRenamePlannerTest.kt
+++ b/build-logic/src/test/kotlin/ukpt/template/ProjectRenamePlannerTest.kt
@@ -1,0 +1,119 @@
+package ukpt.template
+
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
+
+class ProjectRenamePlannerTest {
+    @TempDir
+    lateinit var repository: Path
+
+    private val request = ProjectRenameRequest(
+        projectName = "sample-app",
+        packageName = "com.example.sample",
+        typePrefix = "SampleApp",
+    )
+
+    @Test
+    fun classifiesReplaceReviewAndKeepOccurrences() {
+        write(
+            "app/src/main/kotlin/com/isaacudy/ukpt/Main.kt",
+            "package com.isaacudy.ukpt\nclass UkptApplication\nval key = \"ukpt.projectName\"",
+        )
+        write("app/build.gradle.kts", "plugins { id(\"ukpt.compose-library\") }")
+        write("feature/core/Core.kt", "package feature.ukpt\nimport com.isaacudy.ukpt.App\nclass UkptScreen")
+        write(".agents/skills/ukpt-example/SKILL.md", "name: ukpt-example")
+        write("gradle.properties", "ukpt.projectName=ukpt")
+
+        val plan = ProjectRenamePlanner.plan(repository, request)
+
+        assertTrue(plan.occurrences.any {
+            it.path.endsWith("Main.kt") && it.source == "com.isaacudy.ukpt" &&
+                it.disposition == RenameDisposition.REPLACE
+        })
+        assertTrue(plan.occurrences.any {
+            it.path.endsWith("Main.kt") && it.source == "ukpt" &&
+                it.disposition == RenameDisposition.KEEP
+        })
+        assertTrue(plan.occurrences.any {
+            it.path == "app/build.gradle.kts" && it.source == "ukpt" &&
+                it.disposition == RenameDisposition.KEEP
+        })
+        assertTrue(plan.occurrences.any {
+            it.path == "feature/core/Core.kt" && it.source == "feature.ukpt" &&
+                it.disposition == RenameDisposition.REVIEW
+        })
+        assertTrue(plan.occurrences.any {
+            it.path == "feature/core/Core.kt" && it.source == "com.isaacudy.ukpt" &&
+                it.disposition == RenameDisposition.REPLACE
+        })
+        assertTrue(plan.occurrences.any {
+            it.path.endsWith("Main.kt") && it.source == "Ukpt" && it.replacement == "SampleApp"
+        })
+        assertTrue(plan.occurrences.any {
+            it.path.startsWith(".agents/") && it.disposition == RenameDisposition.KEEP
+        })
+        assertEquals(
+            listOf(
+                DirectoryMove(
+                    "app/src/main/kotlin/com/isaacudy/ukpt",
+                    "app/src/main/kotlin/com/example/sample",
+                ),
+            ),
+            plan.directoryMoves,
+        )
+    }
+
+    @Test
+    fun usesAValidLowerCamelPrefixAndReviewsWorkedCoreReferences() {
+        write(
+            "app/src/main/kotlin/com/isaacudy/ukpt/App.kt",
+            """
+            import feature.ukpt.ukptClientDependencies
+            import feature.ukpt.ui.UkptDestination
+
+            val modules = ukptClientDependencies
+            val destination = UkptDestination
+            val title = "ukpt"
+            """.trimIndent(),
+        )
+
+        val occurrences = ProjectRenamePlanner.plan(repository, request).occurrences
+
+        assertTrue(occurrences.any {
+            it.source == "ukpt" && it.replacement == "SampleApp".replaceFirstChar(Char::lowercaseChar) &&
+                it.disposition == RenameDisposition.REVIEW
+        })
+        assertTrue(occurrences.any {
+            it.source == "Ukpt" && it.replacement == "SampleApp" &&
+                it.disposition == RenameDisposition.REVIEW
+        })
+        assertTrue(occurrences.any {
+            it.source == "ukpt" && it.replacement == "sample-app" &&
+                it.disposition == RenameDisposition.REPLACE
+        })
+    }
+
+    @Test
+    fun rejectsUnsafeIdentityValues() {
+        val errors = ProjectRenamePlanner.validate(
+            ProjectRenameRequest(
+                projectName = "../Sample",
+                packageName = "Example",
+                typePrefix = "sample-app",
+            ),
+        )
+
+        assertEquals(3, errors.size)
+    }
+
+    private fun write(relativePath: String, contents: String) {
+        val file = repository.resolve(relativePath)
+        file.parent.createDirectories()
+        file.writeText(contents)
+    }
+}

--- a/build-logic/src/test/kotlin/ukpt/template/TemplateRepositoryValidatorTest.kt
+++ b/build-logic/src/test/kotlin/ukpt/template/TemplateRepositoryValidatorTest.kt
@@ -1,0 +1,90 @@
+package ukpt.template
+
+import java.nio.file.Files
+import java.nio.file.Path
+import kotlin.io.path.createDirectories
+import kotlin.io.path.writeText
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.io.TempDir
+
+class TemplateRepositoryValidatorTest {
+    @TempDir
+    lateinit var repository: Path
+
+    @Test
+    fun acceptsValidTemplateMetadataAndSkills() {
+        createValidRepository()
+
+        assertEquals(emptyList(), TemplateRepositoryValidator.validate(repository))
+    }
+
+    @Test
+    fun reportsMarkerMigrationGuidanceAndLinkFailuresTogether() {
+        createValidRepository()
+        repository.resolve(".ukpt/template.json").writeText("""{"templateVersion":"2026-99-01"}""")
+        repository.resolve("docs/template-migrations/2026-07-15.2-example.md").writeText("# Example\n")
+        Files.delete(repository.resolve(".claude/skills/ukpt-example"))
+        repository.resolve(".claude/skills/ukpt-example").writeText("not a link")
+        repository.resolve("CLAUDE.md").writeText("@UKPT.md\n")
+
+        val issues = TemplateRepositoryValidator.validate(repository)
+
+        assertTrue(issues.any { it.path == ".ukpt/template.json" && "invalid calendar date" in it.message })
+        assertTrue(issues.any { it.path.endsWith("example.md") && "missing '## Detection'" in it.message })
+        assertTrue(issues.any { it.path == "CLAUDE.md" && "@AGENTS.md" in it.message })
+        assertTrue(issues.any { it.path == ".claude/skills/ukpt-example" && "symbolic link" in it.message })
+    }
+
+    private fun createValidRepository() {
+        repository.resolve(".ukpt").createDirectories()
+        repository.resolve(".ukpt/template.json").writeText("""{"templateVersion":"2026-07-15.2"}""")
+
+        repository.resolve("docs/template-migrations").createDirectories()
+        repository.resolve("docs/template-migrations/2026-07-15.1-example.md").writeText(
+            """
+            # Example
+
+            ## Detection
+            Detection.
+
+            ## Migration
+            Migration.
+
+            ## Verification
+            Verification.
+            """.trimIndent(),
+        )
+
+        repository.resolve("AGENTS.md").writeText("Read UKPT.md first.\n")
+        repository.resolve("CLAUDE.md").writeText("@AGENTS.md\n@UKPT.md\n")
+
+        val skill = repository.resolve(".agents/skills/ukpt-example")
+        skill.resolve("agents").createDirectories()
+        skill.resolve("SKILL.md").writeText(
+            """
+            ---
+            name: ukpt-example
+            description: Example UKPT skill used by the validator test.
+            ---
+
+            # Example
+            """.trimIndent(),
+        )
+        skill.resolve("agents/openai.yaml").writeText(
+            """
+            interface:
+              display_name: "Example"
+              short_description: "Example UKPT skill for tests"
+              default_prompt: "Use ${'$'}ukpt-example for an example."
+            """.trimIndent(),
+        )
+
+        val claudeSkills = repository.resolve(".claude/skills").createDirectories()
+        Files.createSymbolicLink(
+            claudeSkills.resolve("ukpt-example"),
+            Path.of("../../.agents/skills/ukpt-example"),
+        )
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,8 @@ buildscript {
 }
 
 plugins {
+    id("ukpt.template-maintenance")
+
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
     alias(libs.plugins.androidApplication) apply false


### PR DESCRIPTION
## Summary

- add a `validateTemplate` task for template metadata, migrations, agent guidance, and shared skill compatibility
- add a deterministic `planProjectRename` report with `REPLACE`, `REVIEW`, and `KEEP` classifications plus fail-fast verification
- document the maintainer and new-project workflows and bump the template version

This is stacked on #11 because the validator checks the shared agent and skill layout introduced there.

## Testing

- `./gradlew -p build-logic test --rerun-tasks` (5 tests)
- `./gradlew validateTemplate`
- repeated identical `planProjectRename` runs with configuration-cache reuse; both tasks executed
- `planProjectRename -Pukpt.renameFailOnReplace=true` failed as expected on the template’s 34 required replacements
- `git diff --check`