### PR TITLE
Context-engineering pass: dedup guidance, honest examples, deferred persistence docs

### DIFF
--- a/.agents/skills/ukpt-feature-slice/SKILL.md
+++ b/.agents/skills/ukpt-feature-slice/SKILL.md
@@ -46,7 +46,7 @@ whatever the project was renamed to downstream — read `platform/client/design`
    - `app/server/build.gradle.kts` → `implementation(projects.feature.<name>.server)` (if using the server).
    - Server DI: the template's `Server.kt` is a placeholder with **no** Koin host — standing that up is the
      `ukpt-urpc-service` skill's job (do it when the feature gets its first service, not at scaffold time).
-6. **Verify** — compile sweep (all 6 targets, UKPT.md), record + verify Paparazzi for the new client
+6. **Verify** — the six-target compile sweep (see UKPT.md §Compiling), record + verify Paparazzi for the new client
    module, and `./gradlew :platform:common:architecture:verifyArchitecture`. If the feature has web UI, run
    the `ukpt-verify-web` skill — a forgotten `viewModelOf` only crashes at runtime on wasm, invisible to compile.
 
@@ -60,16 +60,17 @@ whatever the project was renamed to downstream — read `platform/client/design`
 - **Read tokens, not literals** — a new screen's colours, spacing and text styles come from the
   project's design-system API, exposed by its design module; add
   `implementation(projects.platform.client.design)` to the `:client` module. On the scaffold that API is
-  `<Prefix>Theme.colors`/`.typography` and `<Prefix>Spacing`; a project that authored its own may expose a
-  different accessor (e.g. a `Gt.colors` object, a theme wrapper with no `colors` parameter) — read the
-  design module to confirm before copying the template. `DesignSystemRules.noLiteralsInFeatureUi` audits
-  for literal `Color(0x…)`/`.dp` in `feature..ui..`.
-- **No `ktor-client-cio` in `commonMain`** — it pulls `node:net` and breaks the wasm bundle. CIO lives in
-  `jvmMain`; web uses `ktor-client-js`.
+  `<Prefix>Theme.colors`/`.typography` and `<Prefix>Spacing`, but a project that authored its own may
+  expose a different accessor — read the design module (and the `ukpt-design-system` skill) to confirm
+  before copying the template. `DesignSystemRules.noLiteralsInFeatureUi` audits for literal
+  `Color(0x…)`/`.dp` in `feature..ui..`.
 - **`:server` depends on `libs.udytils.architectureAnnotations`** — solely so `@ArchitectureException` imports.
-- **wasm ViewModel factory**: every screen VM must be `viewModelOf(::<Name>ViewModel)`-registered in
-  `<name>ClientDependencies`, or web throws `Factory.create … not implemented` at runtime (the Koin-backed
-  factory is installed once in `app/client/common/.../UkptNavigation.kt` — don't regenerate it per feature).
+- **Two web/wasm traps at scaffold time** — both pass compilation; the `ukpt-verify-web` skill has the full
+  catalog and how to diagnose them. (1) Keep `ktor-client-cio` out of `commonMain`: it breaks the wasm
+  bundle, so CIO goes in `jvmMain` and web uses `ktor-client-js`. (2) Register every screen VM with
+  `viewModelOf(::<Name>ViewModel)` in `<name>ClientDependencies` (the Koin-backed VM factory itself lives
+  once in `app/client/common/.../UkptNavigation.kt` — don't recreate it per feature), or web crashes at
+  runtime with `Factory.create … not implemented`.
 
 ## Rule cheat-sheet (canonical text in `platform/common/architecture/docs/` — search the ID)
 - **`UiLayer.Screen.screenContentCompanion`** — `<Name>Screen` pairs with an `internal <Name>ScreenContent(state, …)`;

--- a/.agents/skills/ukpt-new-project/SKILL.md
+++ b/.agents/skills/ukpt-new-project/SKILL.md
@@ -106,12 +106,10 @@ project's names. Keep it accurate if the project is ever re-branded.
 
 ## 5. Verify
 
-Run the full matrix before the first commit:
+Run the full verification before the first commit — the six-target compile sweep (see UKPT.md §Compiling)
+first, then the project-specific checks:
 
 ```
-./gradlew :app:client:android:compileDebugKotlin :app:client:desktop:compileKotlin \
-          :app:client:web:compileKotlinWasmJs :app:client:common:compileKotlinIosArm64 \
-          :app:client:common:compileKotlinIosSimulatorArm64 :app:server:compileKotlin
 ./gradlew :platform:common:architecture:verifyArchitecture
 ./gradlew :feature:core:client:verifyPaparazzi --no-configuration-cache
 ./gradlew :platform:client:design:verifyPaparazzi --no-configuration-cache

--- a/.agents/skills/ukpt-template-update/SKILL.md
+++ b/.agents/skills/ukpt-template-update/SKILL.md
@@ -124,12 +124,9 @@ Projects tweak and extend their rule catalogs. Never treat the catalog as templa
 
 ## 7. Verify
 
-The full matrix, from UKPT.md:
+Run the six-target compile sweep (see UKPT.md §Compiling), then:
 
 ```
-./gradlew :app:client:android:compileDebugKotlin :app:client:desktop:compileKotlin \
-          :app:client:web:compileKotlinWasmJs :app:client:common:compileKotlinIosArm64 \
-          :app:client:common:compileKotlinIosSimulatorArm64 :app:server:compileKotlin
 ./gradlew :platform:common:architecture:verifyArchitecture
 ./gradlew :feature:<each>:client:verifyPaparazzi --no-configuration-cache
 ./gradlew validateTemplate

--- a/UKPT.md
+++ b/UKPT.md
@@ -78,7 +78,7 @@ After making changes, compile every platform (client + server) to verify correct
 ```
 The common module's Android / JVM / wasm targets compile transitively via the per-platform app modules; the iOS targets are built directly from `:app:client:common`. There is no `:app:client:ios` **Gradle** module — the iOS app is an Xcode project at `app/client/ios`, which consumes `App.framework` from `:app:client:common`. Compiling the iOS targets does **not** exercise the app: the Compose/Enro entry point (`iosMain/MainViewController.kt`) is only executed when the Xcode app runs, so a change to it must be verified by actually launching the app.
 
-**Web (wasm) caveat — compiling is not enough.** `compileKotlinWasmJs` only type-checks; it does **not** catch wasm bundle/runtime failures — a `node:`-scheme import pulled in by a JVM-only dependency (e.g. `ktor-client-cio`), a missing ViewModel factory (`Factory.create … not implemented`), or the macOS `.DS_Store` IC-cache crash. For any web change, build the actual bundle and run it in a browser:
+**Web (wasm) caveat — compiling is not enough.** `compileKotlinWasmJs` only type-checks; it does **not** catch failures at wasm bundle time or runtime, so for any web change build the actual bundle and run it in a browser (the `ukpt-verify-web` skill catalogs the failure modes — `node:` imports, the missing ViewModel factory, the `.DS_Store` IC crash — and how to diagnose each):
 ```
 ./gradlew :app:client:web:wasmJsBrowserDevelopmentWebpack --no-configuration-cache   # bundles via webpack — surfaces node:/IC errors
 ./gradlew :app:client:web:wasmJsBrowserDevelopmentRun --no-configuration-cache        # serves it — open the URL and confirm it renders

--- a/platform/common/architecture/docs/data.md
+++ b/platform/common/architecture/docs/data.md
@@ -65,6 +65,8 @@ exposing them as `public val` properties.
 
 ##### Examples
 
+> **Illustrative.** `:feature:core` ships its domain interfaces implemented directly as UseCases (`GetGreetingImpl`, `FlowOfGreetingsImpl`, …) and no Repository. The code below shows the shape a Repository takes once a feature composes a Service plus local storage behind its domain interfaces.
+
 A Repository that exposes domain interfaces as `public val` properties, backed by a Service and local storage:
 
 ```kotlin
@@ -78,6 +80,7 @@ internal class UserRepository(
 
     val deleteUser = DeleteUser { id ->
         userService.deleteUser(UserService.DeleteUser.Request(id))
+        userStorage.remove(id) // keep local storage in sync with the service
     }
 }
 ```
@@ -143,6 +146,8 @@ DataStore, etc.
     * **Why:** Storage is the lowest layer of the stack: it should depend on the database or keychain client and nothing higher. Injecting a domain interface, Repository, or Service would embed orchestration logic in the persistence layer.
 
 ##### Examples
+
+> **Illustrative.** `:feature:core` ships no client storage class. The `expect`/`actual` shape below is the pattern for a platform-backed store when a feature needs one.
 
 An `expect`/`actual` Storage class with a platform-specific backing store:
 

--- a/platform/common/architecture/docs/domain.md
+++ b/platform/common/architecture/docs/domain.md
@@ -83,7 +83,28 @@ A `fun interface` that represents a piece of domain-level business logic.
 
 ##### Examples
 
-Domain interfaces showing `@Throws` exceptions, `Flow` returns (the `FlowOf` prefix), and default convenience functions:
+`feature.ukpt`'s domain interfaces are `fun interface`s with an `operator fun invoke` primary function — a plain value-returning one plus three `FlowOf…` variants (the `FlowOf` name prefix is required whenever the primary function returns a `Flow`):
+
+```kotlin
+// feature.ukpt.domain (:api)
+fun interface GetGreeting {
+    suspend operator fun invoke(): String
+}
+
+fun interface FlowOfGreetings {
+    operator fun invoke(): Flow<Greeting>
+}
+
+fun interface FlowOfLatestGreeting {
+    operator fun invoke(): Flow<Greeting?>          // nullable element inside the wrapper
+}
+
+fun interface FlowOfGreetingHistory {
+    operator fun invoke(): Flow<List<Greeting>>     // a stream of a collection of domain objects
+}
+```
+
+Patterns the base template's interfaces don't exercise yet, illustrated — errors via `@Throws` (a `suspend` `@Throws` must include `CancellationException`, or kotlinc rejects the function on iOS), a no-value primary function, a `StateFlow` return, a nested-type parameter, and default convenience functions (which implementations must never override):
 
 ```kotlin
 fun interface CreateUser {
@@ -95,11 +116,11 @@ fun interface CreateUser {
 
 fun interface DeleteUser {
     @Throws(UserNotFoundException::class, CancellationException::class)
-    suspend operator fun invoke(userId: String)
+    suspend operator fun invoke(userId: String)     // no return value
 }
 
 fun interface FlowOfCurrentUser {
-    operator fun invoke(): StateFlow<User?>
+    operator fun invoke(): StateFlow<User?>          // StateFlow is a supported reactive wrapper
 }
 
 fun interface FlowOfUser {
@@ -123,21 +144,16 @@ fun interface FlowOfUsers {
     operator fun invoke(params: Input): Flow<List<User>>
 
     fun allUsers(): Flow<List<User>> {
-        return invoke(UserSearchInput.AllUsers)
+        return invoke(Input.AllUsers)
     }
 
     fun nameContains(searchTerm: String): Flow<List<User>> {
-        return invoke(UserSearchInput.NameContains(searchTerm = searchTerm))
-    }
-
-    fun isFriendOf(userId: String): Flow<List<User>> {
-        return invoke(UserSearchInput.FriendOf(userId = userId))
+        return invoke(Input.NameContains(searchTerm = searchTerm))
     }
 
     sealed interface Input {
         data object AllUsers : Input
         data class NameContains(val searchTerm: String) : Input
-        data class FriendOf(val userId: String) : Input
     }
 }
 
@@ -174,7 +190,17 @@ An immutable type that represents domain-level data.
 
 ##### Examples
 
-Domain objects showing a nested value-class ID, an `init` invariant, and a sealed hierarchy with nested types:
+`feature.ukpt`'s domain object is a flat, immutable `@Serializable data class` — the shape to copy for most domain data:
+
+```kotlin
+// feature.ukpt.domain.Greeting (:api)
+@Serializable
+data class Greeting(
+    val text: String,
+)
+```
+
+Richer shapes the rules also allow, illustrated (the base template's `Greeting` doesn't need them yet) — a nested value-class ID, an `init` invariant, and a sealed hierarchy with nested types:
 
 ```kotlin
 @Serializable
@@ -210,7 +236,7 @@ sealed interface Transport {
         override val id: String,
         override val name: String,
         val fuelType: FuelType,
-    ) {
+    ) : Transport {
         @Serializable
         enum class FuelType {
             Petrol,
@@ -225,7 +251,7 @@ sealed interface Transport {
         override val id: String,
         override val name: String,
         val type: Type,
-    ) {
+    ) : Transport {
         @Serializable
         enum class Type {
             Manual,
@@ -238,7 +264,7 @@ sealed interface Transport {
         override val id: String,
         override val name: String,
         val routeId: String,
-    )
+    ) : Transport
 }
 ```
 

--- a/platform/common/architecture/docs/feature.md
+++ b/platform/common/architecture/docs/feature.md
@@ -52,13 +52,15 @@ The configuration for Dependency Injection (DI) that wires the feature together.
 
 ##### Examples
 
+> **Illustrative.** `:feature:core`'s `:server` is an empty stub, so it registers no urpc service. The binding and `ServiceImpl` below show the shape; stand a real one up with the `ukpt-urpc-service` skill.
+
 Registering a urpc service in `:server`, per `FeatureRules.DependencyModule.urpcServiceBinding`:
 
 ```kotlin
 scope<UrpcCall> {
-    scopedOf(::UserProfileServiceImpl)
-        .bind(UserProfileService::class)
-        .bindService(::UserProfileServiceUrpcBinding)
+    scopedOf(::UserServiceImpl)
+        .bind(UserService::class)
+        .bindService(::UserServiceUrpcBinding)
 }
 ```
 

--- a/platform/common/architecture/docs/services.md
+++ b/platform/common/architecture/docs/services.md
@@ -7,180 +7,87 @@
 
 The `services` axis defines the contract between client and server. The contract lives in
 `:api`, so both sides see it; the server-side implementation lives in `:server` under the same
-package name. The axis covers both the `:api` Service contract and the entire `:server`
-implementation surface: ServiceImpls, internal helpers and orchestrators, and Postgres storage.
-All of it lives under the one `feature..services..` package tree, so the axis is a single
-RuleGroup whose Constructs' package requirements keep the sub-axes (`internal`, `storage`,
-`tools`) disjoint.
+package name. The axis covers the `:api` Service contract and the whole `:server` implementation
+surface — ServiceImpls, internal helpers and orchestrators, and Postgres storage — all under the
+one `feature..services..` package tree, so it is a single RuleGroup whose Constructs' package
+requirements keep the sub-axes (`internal`, `storage`, `tools`) disjoint.
 
-`services` is not a UI-equivalent outer layer. It sits parallel to the `data` axis and is
-consumed by it. On the client, [Repositories](data.md#repository) (in `data`) inject Service
-contracts to call the server. On the server, `services` is where the request-handling
-implementation lives, reaching into `services.storage` for persistence and
-`services.internal.*` for sub-tasks.
+`services` is a sibling of the `data` axis, not an outer shell above it. On the client,
+[Repositories](data.md#repository) (in `data`) inject Service contracts to call the server; on
+the server, `services` is where request handling lives, reaching into `services.storage` for
+persistence and `services.internal` for sub-tasks. Communication uses **urpc**
+(`dev.isaacudy.udytils:urpc-*`): a service is an `@Urpc` interface, and KSP generates the client,
+the server binding, and the wire descriptors. See [Service Interface](#service-interface).
 
-Client/server communication uses **urpc** (`dev.isaacudy.udytils:urpc-*`): a service is an
-`@Urpc` interface, and KSP generates the client, the server binding, and the wire descriptors.
-See [Service Interface](#service-interface).
+Within a feature the cross-axis rules are: `domain` depends on nothing; `services` may depend on
+`domain`; client `data` may depend on `domain` and on `services` contracts (so Repositories can
+call the server); client `ui` may depend on `domain` only; and inside `services` the direction is
+`internal → storage`. Two layer-level rules pin the axis into that graph —
+`ServicesLayer.mustNotDependOnData` and `ServicesLayer.crossFeatureViaApi` (in the [rules](#rules)).
+No axis may depend on `ui`; the dependency graph is summarised under the [domain layer](domain.md).
 
-## Cross-axis dependencies
-
-Within a feature, the cross-axis dependency rules are:
-
-* `domain` may not depend on any other axis. It is the deepest layer.
-* `services` may depend on `domain`.
-* `data` (client only) may depend on `domain` and on `services` contracts, so Repositories can
-  call the server.
-* `ui` (client only) may depend on `domain` only. It must not depend on `data` or `services`
-  directly; calling the server goes through Repositories, which expose
-  [domain interfaces](domain.md#domain-interface) for the UI to consume.
-* No axis may depend on `ui`.
-* Inside `services`, the dependency direction is `internal → storage`. See
-  [`services.storage`](#servicesstorage--postgres-persistence).
-
-Reading these as a directed graph:
-
-* On the client: `ui → domain ← services ← data` (and `data → domain`).
-* On the server: `domain ← services` (with `services` reaching internally into
-  `services.storage` and `services.internal`).
-
-`services` is a sibling of `data`, not an outer shell above it: the contract that `data`
-consumes on the client and `services` itself implements on the server. Two layer-level rules
-enforce the axis's place in that graph: `ServicesLayer.mustNotDependOnData` and
-`ServicesLayer.crossFeatureViaApi`, in the [rules](#rules) below.
+> **Most of the `:server` surface is deferred.** The base template ships no server feature — the
+> only worked example, `feature.ukpt`, is client-side, and `:feature:core:server` is an empty
+> stub. The `services.internal`, `services.storage`, and `services.tools` conventions below are
+> the documented standard for when a feature first needs them; until then their rules pass
+> vacuously, with no code to apply to.
 
 ## `services.internal`
 
-Server-side coordinator and helper classes: the things that do the work the ServiceImpl
-orchestrates. The bare `services.internal` package holds the top-level orchestrators that
-compose multiple subsystems (such as a `SessionProcessingManager`), plus the shared-payload
-data types they pass between them. Each `services.internal.<subsystem>` package is isolated
-under [hierarchical visibility](#hierarchical-visibility-within-servicesinternal).
-
-The package is modelled by five Constructs: [coordinators](#internal-coordinator),
+Server-side coordinators and helpers — the work a ServiceImpl orchestrates. The bare
+`services.internal` package holds the top-level orchestrators that compose multiple subsystems
+(such as a `SessionProcessingManager`) plus the shared-payload data types they pass between
+them; each `services.internal.<subsystem>` is isolated under
+[hierarchical visibility](#hierarchical-visibility-within-servicesinternal). The package is
+modelled by five Constructs — [coordinators](#internal-coordinator),
 [data carriers](#internal-data-carrier), [internal interfaces](#internal-interface),
-[internal exceptions](#internal-exception), and [object helpers](#internal-object-helper).
-Each requires its shape plus residence in `feature.[name].services.internal`.
+[internal exceptions](#internal-exception), and [object helpers](#internal-object-helper) — each
+residing in `feature.[name].services.internal`.
 
 ### Hierarchical visibility within `services.internal`
 
-`ServicesLayer.internalHierarchicalVisibility` (in the [rules](#rules)) isolates each
-subsystem. Inside `feature.[name].services.internal.**`, an import is allowed only if it
-points to:
-
-* the **same package**, or
-* a **descendant** package, or
-* an **ancestor** package, **and only when the imported declaration is a pure data shape**.
-
-Lateral and cousin imports are forbidden outright. Ancestor imports of behaviour-bearing types
-(regular classes, regular interfaces, top-level functions, objects with member functions) are
-forbidden too: they would let a subsystem invoke its parent or use behaviour from a higher
-level, which re-introduces the cross-subsystem coupling the rule prevents.
-
-The exception for data shapes lets orchestrator-mediated composition work: a payload type that
-flows from one subsystem through the orchestrator into another can live at a common ancestor
-(typically bare `services.internal`), and both subsystems may name it without invoking any
-behaviour.
-
-A "data shape" is any of:
-
-* `data class`, `enum class`, `value class`, `data object`,
-* `sealed class` / `sealed interface`,
-* an `object` that holds only `val` constants (no functions).
-
-A subsystem may subdivide into deeper subpackages. The rule applies recursively, so each new
-subpackage inherits the same isolation.
+`ServicesLayer.internalHierarchicalVisibility` (in the [rules](#rules)) isolates each subsystem.
+Inside `feature.[name].services.internal.**`, an import is allowed only from the same package, a
+descendant, or an ancestor — and an ancestor import only when the target is a pure data shape.
+Lateral and cousin imports are forbidden outright, as are ancestor imports of behaviour-bearing
+types, so a subsystem can never invoke its parent or a sibling; cross-subsystem composition
+belongs to the orchestrator at bare `services.internal`, with shared payloads defined at a common
+ancestor. A "data shape" is a `data`/`enum`/`value` class, a `data object`, a `sealed` type, or a
+constants-only `object`. The rule applies recursively to deeper subpackages.
 
 ## `services.storage` — Postgres persistence
 
-> **ukpt status:** the Postgres toolkit lives in the `embedded-udytils` submodule
-> (`:postgres-core/koin/codegen/gradle-plugin/embedded`), so these rules are the documented
-> persistence standard. The `:platform:server:postgres` module that applies the codegen plugin
-> and owns the Flyway migrations is **created when the first server feature needs
-> persistence**; until then the `services.storage` rules pass vacuously (no storage code
-> exists yet).
-
-* **Definition:** A feature's persistence storage classes and mappings, built on
-  **[Exposed](https://github.com/JetBrains/Exposed)** and the **`dev.isaacudy.udytils.postgres`**
-  runtime. That runtime (in the `embedded-udytils` submodule, re-exported by
-  `:platform:server:postgres` via `api(libs.udytils.postgres.core)`) provides `PostgresConfig`,
-  `PostgresMigrator`, `PgNotificationBus`, and the custom Exposed column types
-  (`JsonbColumnType`, `JsonColumnType`, `TextArrayColumnType`, `TimestampColumnType`). Do not
-  re-implement these in feature code; extend the library instead.
-* **Contents (hand-written, in the feature):** [Storage classes](#storage-class)
-  (`[Name]Storage`), [storage records](#storage-record),
-  [mapping functions](#mapping-function) (conventionally collected in `[Name]Mappers.kt`), and
-  [codec objects](#codec-object).
-* **Contents (generated, not in the feature):** the Exposed `Table` objects and `XxxRow` data
-  classes are generated into the **shared `platform.server.postgres.tables` package**
-  (`:platform:server:postgres`) and imported by each feature's storage code. See
-  [generated `Table`/`Row` sources](#generated-tablerow-sources) and
-  [the codegen pipeline](#postgres-codegen-pipeline--runtime).
-
-Storage sits at the bottom of the `services` axis: the dependency direction is
+A feature's persistence — [storage classes](#storage-class) (`[Name]Storage`),
+[storage records](#storage-record), [mapping functions](#mapping-function) (conventionally in
+`[Name]Mappers.kt`), and [codec objects](#codec-object) — built on **Exposed** and the
+**`dev.isaacudy.udytils.postgres`** runtime (in the `embedded-udytils` submodule, re-exported by
+`:platform:server:postgres`). That runtime provides `PostgresConfig`, `PostgresMigrator`,
+`PgNotificationBus`, and the custom Exposed column types; extend the library rather than
+re-implementing them. Storage sits at the bottom of the axis — the direction is
 `internal → storage`, never the reverse (`ServicesLayer.storageMustNotDependOnInternal`, in the
 [rules](#rules)).
 
 ### Generated `Table`/`Row` sources
 
-> All `Table`/`Row` codegen rules (`ServicesLayer.generatedTableRowSources` through
-> `ServicesLayer.rowFakeConstructorAndSetFromRow` in the [rules](#rules)) are guaranteed by the
-> `dev.isaacudy.udytils.postgres` plugin, not by tests: the generated sources live under
-> `build/generated/` and are never scanned. They live in the shared
-> `platform.server.postgres.tables` package, not in any feature's `services.storage`, so they
-> are declared as RuleGroup-level codegen rules rather than feature Constructs.
-
-* **Note:** The plugin registers two tasks: `generatePostgresTables` (the Exposed sources) and
-  `exportPostgresSchema` (the committed `schema.sql` snapshot). Generated files live under
-  `build/generated/source/postgres-tables/`, carry a
-  `Generated by the dev.isaacudy.udytils.postgres Gradle plugin` header, and are not committed.
-
-A Storage class reads via the generated fake-constructor and writes via the `setFromRow`
-extension; see the layer examples after the [rules](#rules).
-
-### Postgres codegen pipeline & runtime
-
-The persistence stack is built on the **`dev.isaacudy.udytils.postgres`** library (developed in
-the `embedded-udytils` submodule) plus **Exposed**, **Flyway**, and a **Zonky** embedded
-Postgres:
-
-* **Schema:** lives only in `:platform:server:postgres/src/main/resources/db/migration/` as
-  Flyway scripts: versioned `V<n>__snake_name.sql` (run once, in order) and repeatable
-  `R__name.sql` (re-run whenever their checksum changes, such as `R__notify_triggers.sql`). A
-  schema change is a **new** `V<n>` file; existing `V<n>` files are never edited in place.
-* **Codegen:** `exportPostgresSchema` Flyway-migrates a throwaway Zonky Postgres and writes a
-  normalised `schema.sql` snapshot; `generatePostgresTables` then emits the Exposed
-  `Table`/`Row` sources from it into `platform.server.postgres.tables`. Both tasks are
-  registered by the `dev.isaacudy.udytils.postgres` Gradle plugin and run before
-  `compileKotlin`.
-* **Runtime ownership:** the DB primitives (`PostgresConfig`, `PostgresMigrator`,
-  `PgNotificationBus`, the column types) live in the udytils library;
-  `:platform:server:postgres` owns only the SQL migrations and codegen wiring and re-exports
-  the runtime; the application (`:app:server`) owns its connection config
-  (`ukptPostgresConfigFromEnv()`), wires `postgresDependencies(config)` (from
-  `dev.isaacudy.udytils.postgres.koin`), and runs `PostgresMigrator.migrate()` before it
-  starts serving.
-
-### Reactive storage flows (`PgNotificationBus`)
-
-A `[Name]Storage` class may expose `Flow` reads that re-query when a Postgres `NOTIFY` fires,
-by injecting `dev.isaacudy.udytils.postgres.PgNotificationBus`. The channel name is a
-`companion object const val CHANNEL` and must match a `pg_notify(...)` trigger in the
-migrations (such as `R__notify_triggers.sql`). The shape is: emit an initial query, then
-`bus.listen(CHANNEL).filter { it == key }.collect { emit(query()) }`. This is convention, not
-a tested rule.
+The Exposed `Table` objects and `XxxRow` data classes are **generated** by the
+`dev.isaacudy.udytils.postgres` Gradle plugin from the Flyway-migrated schema, into the shared
+`platform.server.postgres.tables` package — not in any feature — so the codegen rules
+(`ServicesLayer.generatedTableRowSources` through `ServicesLayer.rowFakeConstructorAndSetFromRow`,
+in the [rules](#rules)) are guaranteed by the plugin, not by tests. A Storage class reads via the
+generated fake-constructor and writes via the `setFromRow` extension; see the layer examples
+after the [rules](#rules). A `[Name]Storage` may also expose `Flow` reads that re-query on a
+Postgres `NOTIFY` via `PgNotificationBus`. The codegen pipeline, Flyway migration conventions,
+and runtime wiring (`:app:server` owns the connection config and runs the migrator) are
+documented by the `dev.isaacudy.udytils.postgres` toolkit in the `embedded-udytils` submodule.
 
 ## `services.tools` (reserved)
 
-Reserved for AI tool-use subclasses, such as `AssistantTool` wrappers around a service. ukpt
-has no AI subsystem, so `services.tools` is intentionally empty: it defines no Construct, and
-any declaration placed here fails the exhaustiveness test until one is defined. Its isolation
-is enforced now, even though the package is empty: see `ServicesLayer.toolsApiContractOnly` in
-the [rules](#rules).
-
-* **Note:** If an AI subsystem is added later, add an `assistantTool` Construct (extends
-  `AssistantTool`, named `[Action][Entity]Tool`) to the `ServicesLayer` group to populate this
-  layer.
+Reserved for AI tool-use subclasses (such as `AssistantTool` wrappers around a service). ukpt
+has no AI subsystem, so `services.tools` is intentionally empty — it defines no Construct, and
+any declaration placed there fails the exhaustiveness test until one is added. Its isolation is
+enforced even while empty: see `ServicesLayer.toolsApiContractOnly` in the [rules](#rules). When
+an AI subsystem arrives, add an `assistantTool` Construct (extends `AssistantTool`, named
+`[Action][Entity]Tool`) to this group.
 
 ##### Constructs
 

--- a/platform/common/architecture/docs/services.md
+++ b/platform/common/architecture/docs/services.md
@@ -220,6 +220,8 @@ the [rules](#rules).
 
 ##### Examples
 
+> **Illustrative.** No feature ships Postgres storage yet — `:platform:server:postgres` (which generates the `Table`/`Row` sources) is created with the first server feature that needs persistence. The read/write below shows the shape against those generated types.
+
 A Storage class reading via the generated fake-constructor and writing via `setFromRow` (see [generated `Table`/`Row` sources](#generated-tablerow-sources)):
 
 ```kotlin
@@ -230,9 +232,9 @@ val row: UserProfileRow? = UserProfilesTable
     .singleOrNull()
     ?.let(::UserProfileRow)
 
-// Write
+// Write (rowToWrite is a non-null UserProfileRow)
 UserProfilesTable.upsert(UserProfilesTable.userId) {
-    it.setFromRow(row)
+    it.setFromRow(rowToWrite)
 }
 ```
 
@@ -270,6 +272,8 @@ server binding, and the wire descriptors from the annotated interface.
     * **Note:** `@Throws` on `suspend` functions must include `kotlin.coroutines.cancellation.CancellationException`.
 
 ##### Examples
+
+> **Illustrative.** `:feature:core` defines no `@Urpc` contract in `:api` (and its `:server` is an empty stub). The contract below shows the shape; add a real one with the `ukpt-urpc-service` skill.
 
 A `@Urpc` service contract in `:api`, with nested `@Serializable` `Request`/`Response` types grouped under per-function `object` namespaces:
 

--- a/platform/common/architecture/docs/ui.md
+++ b/platform/common/architecture/docs/ui.md
@@ -88,7 +88,26 @@ the destination declaration site.
 
 ##### Examples
 
-A dialog/overlay screen: the Destination lives in `:api`, and the property-based `navigationDestination` in `:client` declares `directOverlay()` metadata and resolves its ViewModel via `viewModel()` inside the block.
+`feature.ukpt`'s screen is a function-based `@NavigationDestination`: the entry `UkptScreen` injects its ViewModel with `viewModel()` and delegates to a stateless `internal UkptScreenContent` that takes state plus callbacks (the `screenContentCompanion` and `viewModelInjection` rules):
+
+```kotlin
+// UkptScreen (in :client) — feature.ukpt.ui
+@Composable
+@NavigationDestination(UkptDestination::class)
+fun UkptScreen(
+    viewModel: UkptViewModel = viewModel(),   // viewModel(), not koinViewModel()
+) {
+    val state by viewModel.state.collectAsState()
+    UkptScreenContent(state = state, onGreet = viewModel::onGreetClicked)
+}
+
+// Stateless content: renders state, reports intent via callbacks, so it renders without a
+// ViewModel and is snapshot-testable from a @Preview.
+@Composable
+internal fun UkptScreenContent(state: UkptState, onGreet: () -> Unit) { /* … */ }
+```
+
+A dialog/overlay screen, illustrated (the base template ships only the full-screen `UkptScreen`): the Destination lives in `:api`, and the property-based `navigationDestination` in `:client` declares `directOverlay()` metadata and resolves its ViewModel via `viewModel()` inside the block.
 
 ```kotlin
 // Destination (in :api)
@@ -276,7 +295,17 @@ The complete, immutable representation of a Screen's data at a single point in t
 
 ##### Examples
 
-A State that is a transparent container for domain objects plus calculated properties; display formatting lives with the Screen as a `@Composable` extension property, not in the State.
+`feature.ukpt`'s State is a plain, immutable data-class container; the ViewModel replaces it wholesale with `state.update { copy(...) }`:
+
+```kotlin
+// feature.ukpt.ui.UkptState
+data class UkptState(
+    val message: String = "Hello, ukpt!",
+    val greetings: Int = 0,
+)
+```
+
+When state carries domain objects, add calculated properties for logic — but keep display formatting out of the State and put it with the Screen as a `@Composable` extension property. Illustrated (the base template's `UkptState` is too simple to need either):
 
 ```kotlin
 // feature.user.ui.UserDetailState.kt

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/data/ClientStorage.examples.md
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/data/ClientStorage.examples.md
@@ -1,3 +1,5 @@
+> **Illustrative.** `:feature:core` ships no client storage class. The `expect`/`actual` shape below is the pattern for a platform-backed store when a feature needs one.
+
 An `expect`/`actual` Storage class with a platform-specific backing store:
 
 ```kotlin

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/data/Repository.examples.md
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/data/Repository.examples.md
@@ -1,3 +1,5 @@
+> **Illustrative.** `:feature:core` ships its domain interfaces implemented directly as UseCases (`GetGreetingImpl`, `FlowOfGreetingsImpl`, …) and no Repository. The code below shows the shape a Repository takes once a feature composes a Service plus local storage behind its domain interfaces.
+
 A Repository that exposes domain interfaces as `public val` properties, backed by a Service and local storage:
 
 ```kotlin
@@ -11,6 +13,7 @@ internal class UserRepository(
 
     val deleteUser = DeleteUser { id ->
         userService.deleteUser(UserService.DeleteUser.Request(id))
+        userStorage.remove(id) // keep local storage in sync with the service
     }
 }
 ```

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/domain/DomainInterface.examples.md
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/domain/DomainInterface.examples.md
@@ -1,4 +1,25 @@
-Domain interfaces showing `@Throws` exceptions, `Flow` returns (the `FlowOf` prefix), and default convenience functions:
+`feature.ukpt`'s domain interfaces are `fun interface`s with an `operator fun invoke` primary function — a plain value-returning one plus three `FlowOf…` variants (the `FlowOf` name prefix is required whenever the primary function returns a `Flow`):
+
+```kotlin
+// feature.ukpt.domain (:api)
+fun interface GetGreeting {
+    suspend operator fun invoke(): String
+}
+
+fun interface FlowOfGreetings {
+    operator fun invoke(): Flow<Greeting>
+}
+
+fun interface FlowOfLatestGreeting {
+    operator fun invoke(): Flow<Greeting?>          // nullable element inside the wrapper
+}
+
+fun interface FlowOfGreetingHistory {
+    operator fun invoke(): Flow<List<Greeting>>     // a stream of a collection of domain objects
+}
+```
+
+Patterns the base template's interfaces don't exercise yet, illustrated — errors via `@Throws` (a `suspend` `@Throws` must include `CancellationException`, or kotlinc rejects the function on iOS), a no-value primary function, a `StateFlow` return, a nested-type parameter, and default convenience functions (which implementations must never override):
 
 ```kotlin
 fun interface CreateUser {
@@ -10,11 +31,11 @@ fun interface CreateUser {
 
 fun interface DeleteUser {
     @Throws(UserNotFoundException::class, CancellationException::class)
-    suspend operator fun invoke(userId: String)
+    suspend operator fun invoke(userId: String)     // no return value
 }
 
 fun interface FlowOfCurrentUser {
-    operator fun invoke(): StateFlow<User?>
+    operator fun invoke(): StateFlow<User?>          // StateFlow is a supported reactive wrapper
 }
 
 fun interface FlowOfUser {
@@ -38,21 +59,16 @@ fun interface FlowOfUsers {
     operator fun invoke(params: Input): Flow<List<User>>
 
     fun allUsers(): Flow<List<User>> {
-        return invoke(UserSearchInput.AllUsers)
+        return invoke(Input.AllUsers)
     }
 
     fun nameContains(searchTerm: String): Flow<List<User>> {
-        return invoke(UserSearchInput.NameContains(searchTerm = searchTerm))
-    }
-
-    fun isFriendOf(userId: String): Flow<List<User>> {
-        return invoke(UserSearchInput.FriendOf(userId = userId))
+        return invoke(Input.NameContains(searchTerm = searchTerm))
     }
 
     sealed interface Input {
         data object AllUsers : Input
         data class NameContains(val searchTerm: String) : Input
-        data class FriendOf(val userId: String) : Input
     }
 }
 

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/domain/DomainObject.examples.md
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/domain/DomainObject.examples.md
@@ -1,4 +1,14 @@
-Domain objects showing a nested value-class ID, an `init` invariant, and a sealed hierarchy with nested types:
+`feature.ukpt`'s domain object is a flat, immutable `@Serializable data class` — the shape to copy for most domain data:
+
+```kotlin
+// feature.ukpt.domain.Greeting (:api)
+@Serializable
+data class Greeting(
+    val text: String,
+)
+```
+
+Richer shapes the rules also allow, illustrated (the base template's `Greeting` doesn't need them yet) — a nested value-class ID, an `init` invariant, and a sealed hierarchy with nested types:
 
 ```kotlin
 @Serializable
@@ -34,7 +44,7 @@ sealed interface Transport {
         override val id: String,
         override val name: String,
         val fuelType: FuelType,
-    ) {
+    ) : Transport {
         @Serializable
         enum class FuelType {
             Petrol,
@@ -49,7 +59,7 @@ sealed interface Transport {
         override val id: String,
         override val name: String,
         val type: Type,
-    ) {
+    ) : Transport {
         @Serializable
         enum class Type {
             Manual,
@@ -62,6 +72,6 @@ sealed interface Transport {
         override val id: String,
         override val name: String,
         val routeId: String,
-    )
+    ) : Transport
 }
 ```

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/feature/DependencyModule.examples.md
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/feature/DependencyModule.examples.md
@@ -1,10 +1,12 @@
+> **Illustrative.** `:feature:core`'s `:server` is an empty stub, so it registers no urpc service. The binding and `ServiceImpl` below show the shape; stand a real one up with the `ukpt-urpc-service` skill.
+
 Registering a urpc service in `:server`, per `FeatureRules.DependencyModule.urpcServiceBinding`:
 
 ```kotlin
 scope<UrpcCall> {
-    scopedOf(::UserProfileServiceImpl)
-        .bind(UserProfileService::class)
-        .bindService(::UserProfileServiceUrpcBinding)
+    scopedOf(::UserServiceImpl)
+        .bind(UserService::class)
+        .bindService(::UserServiceUrpcBinding)
 }
 ```
 

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/services/ServiceInterface.examples.md
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/services/ServiceInterface.examples.md
@@ -1,3 +1,5 @@
+> **Illustrative.** `:feature:core` defines no `@Urpc` contract in `:api` (and its `:server` is an empty stub). The contract below shows the shape; add a real one with the `ukpt-urpc-service` skill.
+
 A `@Urpc` service contract in `:api`, with nested `@Serializable` `Request`/`Response` types grouped under per-function `object` namespaces:
 
 ```kotlin

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/services/ServicesLayer.examples.md
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/services/ServicesLayer.examples.md
@@ -1,3 +1,5 @@
+> **Illustrative.** No feature ships Postgres storage yet — `:platform:server:postgres` (which generates the `Table`/`Row` sources) is created with the first server feature that needs persistence. The read/write below shows the shape against those generated types.
+
 A Storage class reading via the generated fake-constructor and writing via `setFromRow` (see [generated `Table`/`Row` sources](#generated-tablerow-sources)):
 
 ```kotlin
@@ -8,8 +10,8 @@ val row: UserProfileRow? = UserProfilesTable
     .singleOrNull()
     ?.let(::UserProfileRow)
 
-// Write
+// Write (rowToWrite is a non-null UserProfileRow)
 UserProfilesTable.upsert(UserProfilesTable.userId) {
-    it.setFromRow(row)
+    it.setFromRow(rowToWrite)
 }
 ```

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/services/ServicesLayer.kt
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/services/ServicesLayer.kt
@@ -15,180 +15,87 @@ import com.lemonappdev.konsist.api.provider.KoFullyQualifiedNameProvider
 @Describe("""
     The `services` axis defines the contract between client and server. The contract lives in
     `:api`, so both sides see it; the server-side implementation lives in `:server` under the same
-    package name. The axis covers both the `:api` Service contract and the entire `:server`
-    implementation surface: ServiceImpls, internal helpers and orchestrators, and Postgres storage.
-    All of it lives under the one `feature..services..` package tree, so the axis is a single
-    RuleGroup whose Constructs' package requirements keep the sub-axes (`internal`, `storage`,
-    `tools`) disjoint.
+    package name. The axis covers the `:api` Service contract and the whole `:server` implementation
+    surface — ServiceImpls, internal helpers and orchestrators, and Postgres storage — all under the
+    one `feature..services..` package tree, so it is a single RuleGroup whose Constructs' package
+    requirements keep the sub-axes (`internal`, `storage`, `tools`) disjoint.
 
-    `services` is not a UI-equivalent outer layer. It sits parallel to the `data` axis and is
-    consumed by it. On the client, [Repositories](data.md#repository) (in `data`) inject Service
-    contracts to call the server. On the server, `services` is where the request-handling
-    implementation lives, reaching into `services.storage` for persistence and
-    `services.internal.*` for sub-tasks.
+    `services` is a sibling of the `data` axis, not an outer shell above it. On the client,
+    [Repositories](data.md#repository) (in `data`) inject Service contracts to call the server; on
+    the server, `services` is where request handling lives, reaching into `services.storage` for
+    persistence and `services.internal` for sub-tasks. Communication uses **urpc**
+    (`dev.isaacudy.udytils:urpc-*`): a service is an `@Urpc` interface, and KSP generates the client,
+    the server binding, and the wire descriptors. See [Service Interface](#service-interface).
 
-    Client/server communication uses **urpc** (`dev.isaacudy.udytils:urpc-*`): a service is an
-    `@Urpc` interface, and KSP generates the client, the server binding, and the wire descriptors.
-    See [Service Interface](#service-interface).
+    Within a feature the cross-axis rules are: `domain` depends on nothing; `services` may depend on
+    `domain`; client `data` may depend on `domain` and on `services` contracts (so Repositories can
+    call the server); client `ui` may depend on `domain` only; and inside `services` the direction is
+    `internal → storage`. Two layer-level rules pin the axis into that graph —
+    `ServicesLayer.mustNotDependOnData` and `ServicesLayer.crossFeatureViaApi` (in the [rules](#rules)).
+    No axis may depend on `ui`; the dependency graph is summarised under the [domain layer](domain.md).
 
-    ## Cross-axis dependencies
-
-    Within a feature, the cross-axis dependency rules are:
-
-    * `domain` may not depend on any other axis. It is the deepest layer.
-    * `services` may depend on `domain`.
-    * `data` (client only) may depend on `domain` and on `services` contracts, so Repositories can
-      call the server.
-    * `ui` (client only) may depend on `domain` only. It must not depend on `data` or `services`
-      directly; calling the server goes through Repositories, which expose
-      [domain interfaces](domain.md#domain-interface) for the UI to consume.
-    * No axis may depend on `ui`.
-    * Inside `services`, the dependency direction is `internal → storage`. See
-      [`services.storage`](#servicesstorage--postgres-persistence).
-
-    Reading these as a directed graph:
-
-    * On the client: `ui → domain ← services ← data` (and `data → domain`).
-    * On the server: `domain ← services` (with `services` reaching internally into
-      `services.storage` and `services.internal`).
-
-    `services` is a sibling of `data`, not an outer shell above it: the contract that `data`
-    consumes on the client and `services` itself implements on the server. Two layer-level rules
-    enforce the axis's place in that graph: `ServicesLayer.mustNotDependOnData` and
-    `ServicesLayer.crossFeatureViaApi`, in the [rules](#rules) below.
+    > **Most of the `:server` surface is deferred.** The base template ships no server feature — the
+    > only worked example, `feature.ukpt`, is client-side, and `:feature:core:server` is an empty
+    > stub. The `services.internal`, `services.storage`, and `services.tools` conventions below are
+    > the documented standard for when a feature first needs them; until then their rules pass
+    > vacuously, with no code to apply to.
 
     ## `services.internal`
 
-    Server-side coordinator and helper classes: the things that do the work the ServiceImpl
-    orchestrates. The bare `services.internal` package holds the top-level orchestrators that
-    compose multiple subsystems (such as a `SessionProcessingManager`), plus the shared-payload
-    data types they pass between them. Each `services.internal.<subsystem>` package is isolated
-    under [hierarchical visibility](#hierarchical-visibility-within-servicesinternal).
-
-    The package is modelled by five Constructs: [coordinators](#internal-coordinator),
+    Server-side coordinators and helpers — the work a ServiceImpl orchestrates. The bare
+    `services.internal` package holds the top-level orchestrators that compose multiple subsystems
+    (such as a `SessionProcessingManager`) plus the shared-payload data types they pass between
+    them; each `services.internal.<subsystem>` is isolated under
+    [hierarchical visibility](#hierarchical-visibility-within-servicesinternal). The package is
+    modelled by five Constructs — [coordinators](#internal-coordinator),
     [data carriers](#internal-data-carrier), [internal interfaces](#internal-interface),
-    [internal exceptions](#internal-exception), and [object helpers](#internal-object-helper).
-    Each requires its shape plus residence in `feature.[name].services.internal`.
+    [internal exceptions](#internal-exception), and [object helpers](#internal-object-helper) — each
+    residing in `feature.[name].services.internal`.
 
     ### Hierarchical visibility within `services.internal`
 
-    `ServicesLayer.internalHierarchicalVisibility` (in the [rules](#rules)) isolates each
-    subsystem. Inside `feature.[name].services.internal.**`, an import is allowed only if it
-    points to:
-
-    * the **same package**, or
-    * a **descendant** package, or
-    * an **ancestor** package, **and only when the imported declaration is a pure data shape**.
-
-    Lateral and cousin imports are forbidden outright. Ancestor imports of behaviour-bearing types
-    (regular classes, regular interfaces, top-level functions, objects with member functions) are
-    forbidden too: they would let a subsystem invoke its parent or use behaviour from a higher
-    level, which re-introduces the cross-subsystem coupling the rule prevents.
-
-    The exception for data shapes lets orchestrator-mediated composition work: a payload type that
-    flows from one subsystem through the orchestrator into another can live at a common ancestor
-    (typically bare `services.internal`), and both subsystems may name it without invoking any
-    behaviour.
-
-    A "data shape" is any of:
-
-    * `data class`, `enum class`, `value class`, `data object`,
-    * `sealed class` / `sealed interface`,
-    * an `object` that holds only `val` constants (no functions).
-
-    A subsystem may subdivide into deeper subpackages. The rule applies recursively, so each new
-    subpackage inherits the same isolation.
+    `ServicesLayer.internalHierarchicalVisibility` (in the [rules](#rules)) isolates each subsystem.
+    Inside `feature.[name].services.internal.**`, an import is allowed only from the same package, a
+    descendant, or an ancestor — and an ancestor import only when the target is a pure data shape.
+    Lateral and cousin imports are forbidden outright, as are ancestor imports of behaviour-bearing
+    types, so a subsystem can never invoke its parent or a sibling; cross-subsystem composition
+    belongs to the orchestrator at bare `services.internal`, with shared payloads defined at a common
+    ancestor. A "data shape" is a `data`/`enum`/`value` class, a `data object`, a `sealed` type, or a
+    constants-only `object`. The rule applies recursively to deeper subpackages.
 
     ## `services.storage` — Postgres persistence
 
-    > **ukpt status:** the Postgres toolkit lives in the `embedded-udytils` submodule
-    > (`:postgres-core/koin/codegen/gradle-plugin/embedded`), so these rules are the documented
-    > persistence standard. The `:platform:server:postgres` module that applies the codegen plugin
-    > and owns the Flyway migrations is **created when the first server feature needs
-    > persistence**; until then the `services.storage` rules pass vacuously (no storage code
-    > exists yet).
-
-    * **Definition:** A feature's persistence storage classes and mappings, built on
-      **[Exposed](https://github.com/JetBrains/Exposed)** and the **`dev.isaacudy.udytils.postgres`**
-      runtime. That runtime (in the `embedded-udytils` submodule, re-exported by
-      `:platform:server:postgres` via `api(libs.udytils.postgres.core)`) provides `PostgresConfig`,
-      `PostgresMigrator`, `PgNotificationBus`, and the custom Exposed column types
-      (`JsonbColumnType`, `JsonColumnType`, `TextArrayColumnType`, `TimestampColumnType`). Do not
-      re-implement these in feature code; extend the library instead.
-    * **Contents (hand-written, in the feature):** [Storage classes](#storage-class)
-      (`[Name]Storage`), [storage records](#storage-record),
-      [mapping functions](#mapping-function) (conventionally collected in `[Name]Mappers.kt`), and
-      [codec objects](#codec-object).
-    * **Contents (generated, not in the feature):** the Exposed `Table` objects and `XxxRow` data
-      classes are generated into the **shared `platform.server.postgres.tables` package**
-      (`:platform:server:postgres`) and imported by each feature's storage code. See
-      [generated `Table`/`Row` sources](#generated-tablerow-sources) and
-      [the codegen pipeline](#postgres-codegen-pipeline--runtime).
-
-    Storage sits at the bottom of the `services` axis: the dependency direction is
+    A feature's persistence — [storage classes](#storage-class) (`[Name]Storage`),
+    [storage records](#storage-record), [mapping functions](#mapping-function) (conventionally in
+    `[Name]Mappers.kt`), and [codec objects](#codec-object) — built on **Exposed** and the
+    **`dev.isaacudy.udytils.postgres`** runtime (in the `embedded-udytils` submodule, re-exported by
+    `:platform:server:postgres`). That runtime provides `PostgresConfig`, `PostgresMigrator`,
+    `PgNotificationBus`, and the custom Exposed column types; extend the library rather than
+    re-implementing them. Storage sits at the bottom of the axis — the direction is
     `internal → storage`, never the reverse (`ServicesLayer.storageMustNotDependOnInternal`, in the
     [rules](#rules)).
 
     ### Generated `Table`/`Row` sources
 
-    > All `Table`/`Row` codegen rules (`ServicesLayer.generatedTableRowSources` through
-    > `ServicesLayer.rowFakeConstructorAndSetFromRow` in the [rules](#rules)) are guaranteed by the
-    > `dev.isaacudy.udytils.postgres` plugin, not by tests: the generated sources live under
-    > `build/generated/` and are never scanned. They live in the shared
-    > `platform.server.postgres.tables` package, not in any feature's `services.storage`, so they
-    > are declared as RuleGroup-level codegen rules rather than feature Constructs.
-
-    * **Note:** The plugin registers two tasks: `generatePostgresTables` (the Exposed sources) and
-      `exportPostgresSchema` (the committed `schema.sql` snapshot). Generated files live under
-      `build/generated/source/postgres-tables/`, carry a
-      `Generated by the dev.isaacudy.udytils.postgres Gradle plugin` header, and are not committed.
-
-    A Storage class reads via the generated fake-constructor and writes via the `setFromRow`
-    extension; see the layer examples after the [rules](#rules).
-
-    ### Postgres codegen pipeline & runtime
-
-    The persistence stack is built on the **`dev.isaacudy.udytils.postgres`** library (developed in
-    the `embedded-udytils` submodule) plus **Exposed**, **Flyway**, and a **Zonky** embedded
-    Postgres:
-
-    * **Schema:** lives only in `:platform:server:postgres/src/main/resources/db/migration/` as
-      Flyway scripts: versioned `V<n>__snake_name.sql` (run once, in order) and repeatable
-      `R__name.sql` (re-run whenever their checksum changes, such as `R__notify_triggers.sql`). A
-      schema change is a **new** `V<n>` file; existing `V<n>` files are never edited in place.
-    * **Codegen:** `exportPostgresSchema` Flyway-migrates a throwaway Zonky Postgres and writes a
-      normalised `schema.sql` snapshot; `generatePostgresTables` then emits the Exposed
-      `Table`/`Row` sources from it into `platform.server.postgres.tables`. Both tasks are
-      registered by the `dev.isaacudy.udytils.postgres` Gradle plugin and run before
-      `compileKotlin`.
-    * **Runtime ownership:** the DB primitives (`PostgresConfig`, `PostgresMigrator`,
-      `PgNotificationBus`, the column types) live in the udytils library;
-      `:platform:server:postgres` owns only the SQL migrations and codegen wiring and re-exports
-      the runtime; the application (`:app:server`) owns its connection config
-      (`ukptPostgresConfigFromEnv()`), wires `postgresDependencies(config)` (from
-      `dev.isaacudy.udytils.postgres.koin`), and runs `PostgresMigrator.migrate()` before it
-      starts serving.
-
-    ### Reactive storage flows (`PgNotificationBus`)
-
-    A `[Name]Storage` class may expose `Flow` reads that re-query when a Postgres `NOTIFY` fires,
-    by injecting `dev.isaacudy.udytils.postgres.PgNotificationBus`. The channel name is a
-    `companion object const val CHANNEL` and must match a `pg_notify(...)` trigger in the
-    migrations (such as `R__notify_triggers.sql`). The shape is: emit an initial query, then
-    `bus.listen(CHANNEL).filter { it == key }.collect { emit(query()) }`. This is convention, not
-    a tested rule.
+    The Exposed `Table` objects and `XxxRow` data classes are **generated** by the
+    `dev.isaacudy.udytils.postgres` Gradle plugin from the Flyway-migrated schema, into the shared
+    `platform.server.postgres.tables` package — not in any feature — so the codegen rules
+    (`ServicesLayer.generatedTableRowSources` through `ServicesLayer.rowFakeConstructorAndSetFromRow`,
+    in the [rules](#rules)) are guaranteed by the plugin, not by tests. A Storage class reads via the
+    generated fake-constructor and writes via the `setFromRow` extension; see the layer examples
+    after the [rules](#rules). A `[Name]Storage` may also expose `Flow` reads that re-query on a
+    Postgres `NOTIFY` via `PgNotificationBus`. The codegen pipeline, Flyway migration conventions,
+    and runtime wiring (`:app:server` owns the connection config and runs the migrator) are
+    documented by the `dev.isaacudy.udytils.postgres` toolkit in the `embedded-udytils` submodule.
 
     ## `services.tools` (reserved)
 
-    Reserved for AI tool-use subclasses, such as `AssistantTool` wrappers around a service. ukpt
-    has no AI subsystem, so `services.tools` is intentionally empty: it defines no Construct, and
-    any declaration placed here fails the exhaustiveness test until one is defined. Its isolation
-    is enforced now, even though the package is empty: see `ServicesLayer.toolsApiContractOnly` in
-    the [rules](#rules).
-
-    * **Note:** If an AI subsystem is added later, add an `assistantTool` Construct (extends
-      `AssistantTool`, named `[Action][Entity]Tool`) to the `ServicesLayer` group to populate this
-      layer.
+    Reserved for AI tool-use subclasses (such as `AssistantTool` wrappers around a service). ukpt
+    has no AI subsystem, so `services.tools` is intentionally empty — it defines no Construct, and
+    any declaration placed there fails the exhaustiveness test until one is added. Its isolation is
+    enforced even while empty: see `ServicesLayer.toolsApiContractOnly` in the [rules](#rules). When
+    an AI subsystem arrives, add an `assistantTool` Construct (extends `AssistantTool`, named
+    `[Action][Entity]Tool`) to this group.
 """)
 object ServicesLayer : RuleGroup(
     inPackage = "feature..services..",

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/ui/Screen.examples.md
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/ui/Screen.examples.md
@@ -1,4 +1,23 @@
-A dialog/overlay screen: the Destination lives in `:api`, and the property-based `navigationDestination` in `:client` declares `directOverlay()` metadata and resolves its ViewModel via `viewModel()` inside the block.
+`feature.ukpt`'s screen is a function-based `@NavigationDestination`: the entry `UkptScreen` injects its ViewModel with `viewModel()` and delegates to a stateless `internal UkptScreenContent` that takes state plus callbacks (the `screenContentCompanion` and `viewModelInjection` rules):
+
+```kotlin
+// UkptScreen (in :client) — feature.ukpt.ui
+@Composable
+@NavigationDestination(UkptDestination::class)
+fun UkptScreen(
+    viewModel: UkptViewModel = viewModel(),   // viewModel(), not koinViewModel()
+) {
+    val state by viewModel.state.collectAsState()
+    UkptScreenContent(state = state, onGreet = viewModel::onGreetClicked)
+}
+
+// Stateless content: renders state, reports intent via callbacks, so it renders without a
+// ViewModel and is snapshot-testable from a @Preview.
+@Composable
+internal fun UkptScreenContent(state: UkptState, onGreet: () -> Unit) { /* … */ }
+```
+
+A dialog/overlay screen, illustrated (the base template ships only the full-screen `UkptScreen`): the Destination lives in `:api`, and the property-based `navigationDestination` in `:client` declares `directOverlay()` metadata and resolves its ViewModel via `viewModel()` inside the block.
 
 ```kotlin
 // Destination (in :api)

--- a/platform/common/architecture/src/main/kotlin/architecture/rules/ui/ViewModelState.examples.md
+++ b/platform/common/architecture/src/main/kotlin/architecture/rules/ui/ViewModelState.examples.md
@@ -1,4 +1,14 @@
-A State that is a transparent container for domain objects plus calculated properties; display formatting lives with the Screen as a `@Composable` extension property, not in the State.
+`feature.ukpt`'s State is a plain, immutable data-class container; the ViewModel replaces it wholesale with `state.update { copy(...) }`:
+
+```kotlin
+// feature.ukpt.ui.UkptState
+data class UkptState(
+    val message: String = "Hello, ukpt!",
+    val greetings: Int = 0,
+)
+```
+
+When state carries domain objects, add calculated properties for logic — but keep display formatting out of the State and put it with the Screen as a `@Composable` extension property. Illustrated (the base template's `UkptState` is too simple to need either):
 
 ```kotlin
 // feature.user.ui.UserDetailState.kt


### PR DESCRIPTION
Applies Anthropic's [context-engineering guidance for Claude 5 / Opus 4.8 generation models](https://claude.com/blog/the-new-rules-of-context-engineering-for-claude-5-generation-models) to the template's agent guidance and generated architecture docs. The guidance's core moves — say-it-once, progressive disclosure, rich references over prose — mapped cleanly onto three concrete cleanups.

The article's headline "rules → judgment" move deliberately does **not** apply here: the architecture rules are Konsist-enforced with stable path IDs and enforcement tags, so this PR touches only narrative, examples, and skills — never a rule. No rule was added, renamed, or tightened, so no template-migration entry or `templateVersion` bump is required (all changes are to template-owned files).

Each tier was adversarially reviewed by Codex before commit.

## Tier 1 — de-duplicate skill/UKPT.md guidance (`712392c`)
Each fact gets one authoritative home; other mentions point to it.
- The six-target compile sweep, inlined verbatim in three places, now points to `UKPT.md §Compiling` from `ukpt-new-project` and `ukpt-template-update`; all four skills that reference it use one phrasing.
- The wasm gotchas: `ukpt-feature-slice`/`UKPT.md` keep the actionable scaffold steps but defer the failure catalog to `ukpt-verify-web` (its subject).
- The design-module accessor caveat points to `ukpt-design-system` instead of re-listing its example.

_Codex review: no information loss or dangling pointers; two wording/consistency nits fixed._

## Tier 2 — make the architecture-doc examples honest (`76bd9d2`)
The rule-doc examples all used an invented `feature.user` feature that exists nowhere in the repo, disjoint from the real worked example (`feature.ukpt` in `:feature:core`).
- **Where real code exists** (DomainObject, DomainInterface, Screen, ViewModelState): examples now lead with the real `feature.ukpt` symbols, keeping richer patterns (`@Throws`, Unit/`StateFlow` returns, overlay dialogs, calculated-property + `@Composable` display extension) clearly marked illustrative so no rule coverage is lost.
- **Where no real code exists** (Repository, ClientStorage, ServiceInterface, ServicesLayer, DependencyModule): an "Illustrative" banner states plainly that `:feature:core` ships no such construct.

_Codex review surfaced eight defects — several **pre-existing bugs** in the original illustrative code (a sealed `Transport` whose variants didn't declare `: Transport`; a nonexistent `UserSearchInput`; a nullable row passed to a non-null `setFromRow`; mismatched service names; unused injected storage) plus two inaccuracies in the new banners — all fixed._

## Tier 3 — defer the persistence subsystem (`1d7ad8b`)
The `ServicesLayer` essay front-loaded a full Postgres/persistence spec (~178 lines) for a subsystem with no code in the repo (`:feature:core:server` is an empty stub; `:platform:server:postgres` isn't created until the first server feature needs persistence). Trimmed to ~85 lines (`services.md` 461 → 372):
- Deduped the cross-axis dependency graph (the domain layer already states it).
- Added a deferral callout: most of the `:server` surface is the documented standard for when a feature needs it; until then the rules pass vacuously.
- Folded the Postgres codegen / runtime / reactive-flow detail into a pointer to the `dev.isaacudy.udytils.postgres` toolkit — its authoritative home in `embedded-udytils`.
- Preserved the three heading anchors other rule files link to.

_Codex review: no defects (anchors, dependency accuracy, retained info, and the toolkit pointer all verified against the submodule)._

## Verification
- `validateTemplate` — passes.
- `:platform:common:architecture:verifyArchitecture` — passes (rules green; generated docs up to date).
- Generated docs regenerated via `updateArchitectureDocumentation`; no hand-edited generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
