### PR TITLE
Split Paparazzi wiring into target-agnostic ukpt.snapshot-testing-base

### DIFF
--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-08-01"
+  "templateVersion": "2026-08-01.1"
 }

--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -9,7 +9,7 @@ dependencies {
     implementation(libs.android.gradlePlugin)
     implementation(libs.compose.gradlePlugin)
     implementation(libs.compose.compiler.gradlePlugin)
-    // Applied by ukpt.snapshot-testing, so it must be on the convention plugins' classpath.
+    // Applied by ukpt.snapshot-testing-base, so it must be on the convention plugins' classpath.
     implementation(libs.paparazzi.gradlePlugin)
 
     testImplementation(libs.kotlin.test)

--- a/build-logic/src/main/kotlin/ukpt.snapshot-testing-base.gradle.kts
+++ b/build-logic/src/main/kotlin/ukpt.snapshot-testing-base.gradle.kts
@@ -1,0 +1,65 @@
+/**
+ * Leaf convention for Paparazzi snapshot-test wiring, independent of the module's target set.
+ *
+ * Applies: KotlinMultiplatform, the AGP 9 Android KMP library plugin, Paparazzi
+ *
+ * Most modules should apply `ukpt.snapshot-testing`, which composes this with the template's
+ * standard target set via `ukpt.compose-library`. This leaf exists for shell modules that
+ * hand-wire their own targets (a named `jvm("desktop")` target, an iOS framework binary, …) and
+ * therefore can't apply `ukpt.compose-library` without gaining a second, unwanted `jvm()` target.
+ * The plugins applied here are the ones such a module already has — applying them again is a
+ * no-op — and none of them declares a non-Android target.
+ *
+ * An Android target is required: Paparazzi runs as an Android host test. A module applying this
+ * still declares its own `androidHostTest` dependency on `dev.isaacudy.udytils:snapshot` (the
+ * harness) and its own `PreviewSnapshotTest` naming the package tree to scan — those are the
+ * module's facts, not boilerplate.
+ *
+ * Snapshot tasks must be run with `--no-configuration-cache`: Paparazzi's resource-preparation
+ * task cannot be stored in the configuration cache.
+ */
+plugins {
+    id("org.jetbrains.kotlin.multiplatform")
+    id("com.android.kotlin.multiplatform.library")
+    id("app.cash.paparazzi")
+}
+
+kotlin {
+    @Suppress("UnstableApiUsage")
+    androidLibrary {
+        // Host (JVM) unit-test component — Paparazzi attaches its record/verify tasks here and
+        // reads the KMP `androidHostTest` source set.
+        withHostTestBuilder {
+        }.configure {
+        }
+
+        // The AGP KMP library plugin disables Android resource processing by default, and with it
+        // the R class Paparazzi resolves reflectively at runtime — without this flag the host
+        // tests die with ClassNotFoundException: <module>.R. ukpt.compose-library also enables it
+        // (for its own reason: packaging composeResources as Android assets); setting it twice is
+        // harmless, and a hand-wired module applying only this leaf needs it from here.
+        androidResources {
+            enable = true
+        }
+    }
+}
+
+// Paparazzi loads R classes (this module's + every dependency's: dev.enro.R, androidx.*.R, …)
+// reflectively at runtime. The KMP library plugin puts the aggregated host-test stub R jar on the
+// *compile* classpath only, so add it to the test runtime classpath via doFirst (which wins over
+// AGP's lazily-provided AndroidUnitTest classpath); otherwise the tests fail with
+// ClassNotFoundException. Adding it to androidHostTestRuntimeOnly would create a cycle, since the
+// stub-R task consumes the runtime classpath as input.
+tasks.withType<Test>().configureEach {
+    if (name == "testAndroidHostTest") {
+        dependsOn("generateAndroidHostTestStubRFile")
+        // Bound outside the doFirst so the closure captures only this FileCollection: capturing
+        // `layout`/`project` would drag the whole script into the task's configuration-cache state.
+        val rJar = files(
+            layout.buildDirectory.file("intermediates/compile_and_runtime_r_class_jar/androidHostTest/generateAndroidHostTestStubRFile/R.jar")
+        )
+        doFirst {
+            classpath = classpath + rJar
+        }
+    }
+}

--- a/build-logic/src/main/kotlin/ukpt.snapshot-testing.gradle.kts
+++ b/build-logic/src/main/kotlin/ukpt.snapshot-testing.gradle.kts
@@ -1,49 +1,14 @@
 /**
  * Convention plugin for Compose modules that snapshot-test their UI with Paparazzi.
  *
- * Applies: ukpt.compose-library, Paparazzi
+ * Applies: ukpt.compose-library, ukpt.snapshot-testing-base
  *
- * This builds on the compose-library convention and adds the host-test component Paparazzi
- * attaches to, plus the stub-R classpath workaround it needs to run. A module applying this still
- * declares its own `androidHostTest` dependency on `dev.isaacudy.udytils:snapshot` (the harness)
- * and its own `PreviewSnapshotTest` naming the package tree to scan — those are the module's
- * facts, not boilerplate.
- *
- * Snapshot tasks must be run with `--no-configuration-cache`: Paparazzi's resource-preparation
- * task cannot be stored in the configuration cache.
+ * This is pure composition: compose-library declares the template's standard KMP target set, and
+ * the base plugin carries the Paparazzi host-test wiring (see its KDoc for what a module still
+ * declares itself, and for the `--no-configuration-cache` requirement). A shell module that
+ * hand-wires its own targets applies `ukpt.snapshot-testing-base` directly instead of this.
  */
 plugins {
     id("ukpt.compose-library")
-    id("app.cash.paparazzi")
-}
-
-kotlin {
-    @Suppress("UnstableApiUsage")
-    androidLibrary {
-        // Host (JVM) unit-test component — Paparazzi attaches its record/verify tasks here and
-        // reads the KMP `androidHostTest` source set.
-        withHostTestBuilder {
-        }.configure {
-        }
-    }
-}
-
-// Paparazzi loads R classes (this module's + every dependency's: dev.enro.R, androidx.*.R, …)
-// reflectively at runtime. The KMP library plugin puts the aggregated host-test stub R jar on the
-// *compile* classpath only, so add it to the test runtime classpath via doFirst (which wins over
-// AGP's lazily-provided AndroidUnitTest classpath); otherwise the tests fail with
-// ClassNotFoundException. Adding it to androidHostTestRuntimeOnly would create a cycle, since the
-// stub-R task consumes the runtime classpath as input.
-tasks.withType<Test>().configureEach {
-    if (name == "testAndroidHostTest") {
-        dependsOn("generateAndroidHostTestStubRFile")
-        // Bound outside the doFirst so the closure captures only this FileCollection: capturing
-        // `layout`/`project` would drag the whole script into the task's configuration-cache state.
-        val rJar = files(
-            layout.buildDirectory.file("intermediates/compile_and_runtime_r_class_jar/androidHostTest/generateAndroidHostTestStubRFile/R.jar")
-        )
-        doFirst {
-            classpath = classpath + rJar
-        }
-    }
+    id("ukpt.snapshot-testing-base")
 }

--- a/docs/template-migrations/2026-08-01.1-snapshot-testing-base.md
+++ b/docs/template-migrations/2026-08-01.1-snapshot-testing-base.md
@@ -1,0 +1,45 @@
+# Paparazzi wiring splits into a target-agnostic leaf: `ukpt.snapshot-testing-base`
+
+`ukpt.snapshot-testing` builds on `ukpt.compose-library`, which declares the template's standard
+KMP target set. A shell module that hand-wires its own targets — a **named** `jvm("desktop")`
+target, an iOS framework binary configuration — could not apply the convention: doing so silently
+registers a second, unwanted `jvm()` target. Such modules were forced to re-copy exactly the
+Paparazzi boilerplate the convention was created to delete (the host-test component and the
+stub-R `doFirst` block).
+
+The Paparazzi wiring now lives in a leaf plugin, `ukpt.snapshot-testing-base`, that assumes
+nothing about the module's target set beyond the Android target Paparazzi itself requires. It also
+enables `androidResources` (the R class Paparazzi resolves reflectively), so it works without
+`ukpt.compose-library` present. `ukpt.snapshot-testing` is now pure composition —
+`ukpt.compose-library` + the leaf — and behaves identically to before.
+
+## Detection
+
+Modules applying `ukpt.snapshot-testing` need no change. A project is affected if a hand-wired
+module copies the Paparazzi wiring instead:
+
+```bash
+grep -rln "generateAndroidHostTestStubRFile" --include="*.gradle.kts" .
+```
+
+Matches outside `build-logic/` are hand-wired modules that should adopt the leaf.
+
+## Migration
+
+1. Sync `build-logic/` from the template; it is template-owned.
+2. In each hand-wired module, add `id("ukpt.snapshot-testing-base")` to the `plugins` block and
+   delete the copied wiring: the Paparazzi plugin alias, the `withHostTestBuilder { }.configure { }`
+   block, any `androidResources { enable = true }` added for the R class, and the entire
+   `tasks.withType<Test>` stub-R block. The module keeps its hand-wired targets, its
+   `androidHostTest` dependency on `dev.isaacudy.udytils:snapshot`, and its `PreviewSnapshotTest`.
+
+## Verification
+
+```bash
+./gradlew :feature:core:client:verifyPaparazzi --no-configuration-cache --max-workers=2
+```
+
+plus the same task on each hand-wired module that adopted the leaf. Existing goldens must pass
+**unchanged** — this migration moves build wiring and changes no rendering behaviour. A
+`ClassNotFoundException` naming a module's `R` class means the leaf (or the `androidResources`
+flag it carries) is not applied.


### PR DESCRIPTION
## What

Stacked on #17.

`ukpt.snapshot-testing` builds on `ukpt.compose-library`, which declares the standard KMP target set — so a shell module that hand-wires its targets (a named `jvm("desktop")` target, an iOS framework binary) couldn't apply it without silently gaining a second, unwanted `jvm()` target. Reglyph's `:app:client:common` hit exactly this and had to re-copy the host-test + stub-R boilerplate the convention exists to delete.

The Paparazzi wiring now lives in a leaf, `ukpt.snapshot-testing-base`, that assumes only the Android target Paparazzi itself requires:

- applies KMP + the AGP KMP library plugin + Paparazzi (all no-ops for a module that already has them; none declares a non-Android target),
- carries the `withHostTestBuilder` registration and the stub-R `doFirst` workaround, moved verbatim,
- enables `androidResources` — the R class Paparazzi resolves reflectively — so it works without `ukpt.compose-library` present (compose-library also sets it, for its own resource-packaging reason; setting it twice is harmless).

`ukpt.snapshot-testing` becomes pure composition (`ukpt.compose-library` + the leaf) and behaves identically. Hand-wired shell modules apply the leaf directly.

## Template versioning

`templateVersion` → `2026-08-01.1`, with migration entry `2026-08-01.1-snapshot-testing-base.md`. Modules applying `ukpt.snapshot-testing` need no change; the entry targets hand-wired modules that copied the wiring.

## Verification

- `./gradlew validateTemplate` — passes.
- `./gradlew :feature:core:client:verifyPaparazzi --no-configuration-cache` — passes with existing goldens unchanged, exercising the recomposed convention end-to-end.
- No template module applies the leaf standalone (the template's shell uses the standard target set), so the standalone path is exercised by build-logic compilation here and for real by downstream adoption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)