### PR TITLE
Re-pin embedded-udytils: urpc-client-rest serves urpc stubs over REST

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -72,6 +72,7 @@ includeBuild("embedded-udytils") {
         substitute(module("dev.isaacudy.udytils:snapshot")).using(project(":snapshot"))
         substitute(module("dev.isaacudy.udytils:urpc-protocol")).using(project(":urpc:protocol"))
         substitute(module("dev.isaacudy.udytils:urpc-client")).using(project(":urpc:client"))
+        substitute(module("dev.isaacudy.udytils:urpc-client-rest")).using(project(":urpc:client-rest"))
         substitute(module("dev.isaacudy.udytils:urpc-server")).using(project(":urpc:server"))
         substitute(module("dev.isaacudy.udytils:urpc-koin")).using(project(":urpc:koin"))
         substitute(module("dev.isaacudy.udytils:urpc-processor")).using(project(":urpc:processor"))


### PR DESCRIPTION
## Summary
- Re-pins the `embedded-udytils` submodule to `a0f6272` (main), pulling in udytils PR #19 which adds `:urpc:client-rest` — a `UrpcClientFactory` backed by a route table over a plain-JSON REST API, for migrating clients onto urpc contracts before the backend moves.
- Adds the composite-build dependency substitution in `settings.gradle.kts`, mapping `dev.isaacudy.udytils:urpc-client-rest` to `project(":urpc:client-rest")` in the `embedded-udytils` includeBuild, next to the existing `urpc-client` entry. This makes the artifact resolvable; nothing consumes it yet.

## Verification
Ran from repo root, foreground, no throttling:
```
./gradlew validateTemplate :platform:common:architecture:verifyArchitecture :app:client:desktop:compileKotlin :app:server:compileKotlin :app:client:web:compileKotlinWasmJs
```
- `validateTemplate` — passed
- `:platform:common:architecture:verifyArchitecture` — passed
- `:app:client:desktop:compileKotlin` — passed
- `:app:server:compileKotlin` — passed
- `:app:client:web:compileKotlinWasmJs` — passed

BUILD SUCCESSFUL, no failures. (No iOS/native tasks — no ukpt source changed and nothing consumes the new module yet.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)