### PR TITLE
Add a WebGL boot fallback to the web scaffold

### DIFF
--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-08-02.1"
+  "templateVersion": "2026-08-03"
 }

--- a/app/client/web/src/wasmJsMain/resources/index.html
+++ b/app/client/web/src/wasmJsMain/resources/index.html
@@ -3,7 +3,52 @@
 <head>
     <meta charset="UTF-8">
     <title>ukpt</title>
-    <script type="application/javascript" src="App.js"></script>
 </head>
-<body></body>
+<body>
+<script>
+    // WebGL pre-flight. skiko (Compose's web renderer) acquires a WebGL context
+    // at startup; when the browser can't provide one — hardware acceleration off,
+    // GPU blocklisted, or contexts exhausted — it dies with an uncaught
+    // "getParameter of undefined" and the page stays blank. The renderer is the
+    // broken part, so the message can't come from Compose: probe here in plain
+    // DOM before the bundle loads and, on failure, show guidance instead of
+    // loading (and trapping) the app. Projects with a boot screen should style
+    // the fallback with their own tokens.
+    (function () {
+        "use strict";
+        function webGlAvailable() {
+            try {
+                var c = document.createElement("canvas");
+                var gl = c.getContext("webgl2") || c.getContext("webgl") ||
+                    c.getContext("experimental-webgl");
+                if (!gl) return false;
+                // Release the probe context so it doesn't occupy one of the
+                // browser's limited WebGL slots.
+                var lose = gl.getExtension("WEBGL_lose_context");
+                if (lose) lose.loseContext();
+                return true;
+            } catch (e) {
+                return false;
+            }
+        }
+
+        if (webGlAvailable()) {
+            var s = document.createElement("script");
+            s.type = "application/javascript";
+            s.src = "App.js";
+            document.body.appendChild(s);
+            return;
+        }
+
+        document.body.innerHTML =
+            '<div role="alert" style="font-family: system-ui, sans-serif; max-width: 34rem;' +
+            ' margin: 15vh auto 0; padding: 0 1.25rem; text-align: center; line-height: 1.5;">' +
+            '<h1 style="font-size: 1.25rem; font-weight: 600;">Graphics acceleration is off</h1>' +
+            '<p>This app renders with WebGL, which your browser isn’t providing — usually because' +
+            ' hardware acceleration is turned off. Turn it on in your browser settings (Chrome or' +
+            ' Edge: <b>Settings → System</b>) and relaunch, or open the app in a different browser.' +
+            '</p></div>';
+    })();
+</script>
+</body>
 </html>

--- a/docs/template-migrations/2026-08-03-webgl-boot-fallback.md
+++ b/docs/template-migrations/2026-08-03-webgl-boot-fallback.md
@@ -1,0 +1,56 @@
+# Web boot shows a WebGL message instead of a blank page
+
+The web target renders with skiko, which acquires a **WebGL** context at startup. When the browser
+cannot provide one — hardware acceleration disabled, GPU blocklisted, or WebGL contexts exhausted —
+skiko dies with an uncaught `getParameter of undefined` during Compose's first frame, and the user
+sees a **blank page** with no explanation.
+
+The scaffold `index.html` now gates the app bundle behind a plain-DOM WebGL probe: it loads the
+bundle only when a context is available, and otherwise replaces the boot screen with an actionable
+message. The fallback is deliberately not Compose — the renderer is the thing that failed, so a
+Compose error screen would fail the same way.
+
+## Detection
+
+A project is affected if its web `index.html` loads the app bundle from static markup with no WebGL
+check:
+
+```bash
+grep -L "webGlAvailable" app/client/web/src/wasmJsMain/resources/index.html
+```
+
+The file being listed (the guard is absent) means the project still shows a blank page when WebGL is
+unavailable.
+
+## Migration
+
+`index.html` is downstream-customized (boot screen, branding), so this is not a file sync — apply
+the guard by hand:
+
+1. Stop loading the app bundle from a static `<script src="…App.js">` tag.
+2. Before load, probe for a context and inject the bundle only when one exists:
+
+   ```js
+   function webGlAvailable() {
+     try {
+       var c = document.createElement("canvas");
+       var gl = c.getContext("webgl2") || c.getContext("webgl") || c.getContext("experimental-webgl");
+       if (!gl) return false;
+       var lose = gl.getExtension("WEBGL_lose_context");   // free the probe context
+       if (lose) lose.loseContext();
+       return true;
+     } catch (e) { return false; }
+   }
+   ```
+
+3. When the probe fails, replace the boot screen with a message that names the cause (hardware
+   acceleration / WebGL) and a next step (turn it on, or try another browser). Reuse your boot
+   screen's tokens so it stays on-brand.
+
+The scaffold `app/client/web/src/wasmJsMain/resources/index.html` is the reference shape.
+
+## Verification
+
+Serve the web app, turn hardware acceleration off in the browser (Chrome or Edge: Settings →
+System), and reload: the message appears in place of a blank page and no uncaught exception is
+logged. Turn it back on and confirm the app boots normally.


### PR DESCRIPTION
## Summary

The web target renders with skiko (Compose's web renderer), which acquires a **WebGL** context at startup. When the browser can't provide one — hardware acceleration disabled, GPU blocklisted, or WebGL contexts exhausted — skiko dies with an uncaught `getParameter of undefined` during Compose's first frame and the user sees a **blank page** with no explanation.

This gates the app bundle behind a plain-DOM WebGL probe in the scaffold `index.html`: the bundle loads only when a context is available, and otherwise the boot screen is replaced with an actionable message (turn hardware acceleration on, or try another browser). The fallback is deliberately not Compose — the renderer is the thing that failed, so a Compose error screen would fail the same way.

This propagates the already-open Reglyph change into the template so future projects inherit it.

## Files changed

- `app/client/web/src/wasmJsMain/resources/index.html` — scaffold now gates `App.js` behind a `webGlAvailable()` probe, with a plain-DOM fallback message.
- `.ukpt/template.json` — `templateVersion` bumped `2026-08-02.1` → `2026-08-03`.
- `docs/template-migrations/2026-08-03-webgl-boot-fallback.md` — new migration entry (index.html is downstream-customized, so the guard is applied by hand, not file-synced).

## Verification

`./gradlew validateTemplate` — **PASS** locally (`UKPT template validation passed`, BUILD SUCCESSFUL). This is the only automated check (the repo has no CI).

## Related

Mirrors the origin PR isaac-udy/arcane-archivist#477.

🤖 Generated with [Claude Code](https://claude.com/claude-code)