### PR TITLE
Wire udytils UI atlas plugin into the template

### DIFF
--- a/.agents/skills/ukpt-ui-atlas/SKILL.md
+++ b/.agents/skills/ukpt-ui-atlas/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ukpt-ui-atlas
+description: >-
+  Generating or consulting the UI atlas, orienting in the app's screens and
+  navigation before UI work, "what screens are there", "what does X screen look
+  like", "what navigates to X".
+---
+
+# ukpt-ui-atlas
+
+The UI atlas is a generated map of every screen (Enro `@NavigationDestination`), its Paparazzi
+golden variants, and the navigation edges between screens. It also synthesizes gallery cards for
+preview goldens that have no matching destination.
+
+## Generating
+
+```
+./gradlew generateUiAtlas
+```
+
+Output lands in `build/ui-atlas/`:
+- `index.html` — interactive atlas (open in a browser to pan, zoom, search, and browse variants).
+- `manifest.json` — machine-readable UI map.
+- `images/` — copied golden PNGs.
+
+Goldens must exist before generating. If screens are missing images, run `recordPaparazzi` for the
+relevant client modules first (see [UKPT.md](../../../UKPT.md) §Testing).
+
+## Agent orientation via `manifest.json`
+
+Before starting UI work, read `build/ui-atlas/manifest.json` (generate it first if it does not
+exist) instead of grepping for destinations. It answers what screens exist, what opens what, and
+which goldens show a screen's states.
+
+### Manifest fields
+
+**`AtlasManifest`** (root):
+- `projectName` — the project name.
+- `generatedAt` — ISO 8601 timestamp.
+- `nodes` — all destination nodes (real and synthetic).
+- `edges` — resolved navigation edges.
+- `unresolvedEdges` — edges the scanner found in source but could not resolve to a known node.
+- `unmatchedGoldens` — golden files that matched no destination.
+- `totalGoldens` — total golden PNG files discovered.
+
+**`AtlasNode`**:
+- `qualifiedName` — fully qualified destination name (`package.DestName`).
+- `destinationName` — simple destination class name.
+- `screenName` — destination name without the `Destination` suffix.
+- `displayName` — human-readable name (disambiguated when duplicates exist).
+- `featureGroup` — feature grouping label.
+- `moduleLabel` — Gradle module path derived from file location.
+- `sourceFile` — repo-relative path to the declaring source file.
+- `packageName` — Kotlin package name.
+- `isWithResult` — `true` if the destination key extends `NavigationKey.WithResult`.
+- `navigationPath` — value from `@NavigationPath`, if present.
+- `isShellActive` — `true` if the screen uses `shellActive()` or `shellEmpty()`.
+- `variants` — matched snapshot variants, each with `label`, `imagePath`, `width`, `height`.
+- `defaultVariantIndex` — index of the default variant to display.
+- `synthetic` — `true` if this node was synthesized from orphan goldens.
+
+**`AtlasEdge`**: `source` and `target` are `qualifiedName` values; `kind` is `OPEN`, `RESULT`,
+or `CHROME`.
+
+**`UnresolvedEdge`**: `file` (repo-relative path), `line`, `text` (the source line).
+
+## Caveats
+
+- Edge scanning is regex-heuristic: it finds `.open(` calls and maps them to known destinations.
+  It does not evaluate code, so edges inside conditionals or generated code may be missed or
+  spurious.
+- Unresolved edges are listed in the manifest (`unresolvedEdges`), not dropped.
+- The atlas auto-discovers source and golden roots by walking the repo and pruning `.gitmodules`
+  submodules, `build/` directories, and dot-dirs.
+
+## Reference
+- Plugin source: [`embedded-udytils/atlas/`](../../../embedded-udytils/atlas/README.md).
+- Model types: [`embedded-udytils/atlas/core/src/main/kotlin/dev/isaacudy/udytils/atlas/AtlasModel.kt`](../../../embedded-udytils/atlas/core/src/main/kotlin/dev/isaacudy/udytils/atlas/AtlasModel.kt).

--- a/.agents/skills/ukpt-ui-atlas/agents/openai.yaml
+++ b/.agents/skills/ukpt-ui-atlas/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Generate UKPT UI Atlas"
+  short_description: "Generate and consult the UI atlas for screen orientation"
+  default_prompt: "Use $ukpt-ui-atlas to generate the UI atlas and orient in the project's screens."

--- a/.claude/skills/ukpt-ui-atlas
+++ b/.claude/skills/ukpt-ui-atlas
@@ -1,0 +1,1 @@
+../../.agents/skills/ukpt-ui-atlas

--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-08-18"
+  "templateVersion": "2026-08-19"
 }

--- a/UKPT.md
+++ b/UKPT.md
@@ -101,6 +101,10 @@ The common module's Android / JVM / wasm targets compile transitively via the pe
   Goldens are **directory-grouped** by the preview's declaring package and function name, so a preview in `feature.ukpt.client.ui` lands at `src/androidHostTest/snapshots/images/feature/ukpt/client/ui/UkptScreenPreview.png`. `DirectorySnapshotHandler` (a custom Paparazzi `SnapshotHandler`) implements that layout; stock Paparazzi can only emit one long flat filename per golden. Two previews resolving to the same golden path fail fast at test-parameter creation rather than silently overwriting one another.
 - **Unit tests**: per KMP module via the umbrella task, e.g. `./gradlew :feature:core:api:allTests :feature:core:client:allTests` — a client module's `allTests` includes the snapshot host test, so it needs `--no-configuration-cache` too (same R-class failure as above). Server coverage lives in **two** modules: `./gradlew :feature:core:server:test :app:server:test` — the feature module holds nearly all of it; `:app:server:test` alone runs only the shell's own tests.
 
+## UI atlas
+
+`./gradlew generateUiAtlas` scans the repo for Enro `@NavigationDestination` nodes, `.open()` navigation edges, and Paparazzi goldens, then writes `build/ui-atlas/`: an interactive `index.html` and a machine-readable `manifest.json` (plus copied golden images). Goldens must already exist — run `recordPaparazzi` first if screens are missing images. The `ukpt-ui-atlas` skill documents the manifest schema and how agents should use it for orientation.
+
 ## Server persistence (Postgres)
 
 Server persistence uses the `dev.isaacudy.udytils.postgres` toolkit (Exposed + Flyway); conventions are in [docs/serverdata.md](./platform/common/architecture/docs/serverdata.md) (the `server.data.storage` section). `:platform:server:postgres` owns the Flyway migrations (`src/main/resources/db/migration/`, empty until the first schema) and the codegen that turns them into Exposed `Table`/`Row` sources; `:platform:server:development` owns the dev-database scenarios.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,9 @@ buildscript {
         // The Postgres codegen plugin, on the classpath for the same reason: resolving it through
         // pluginManagement instead would lose the substitutions above.
         classpath(libs.udytils.postgres.gradlePlugin)
+
+        // The atlas plugin, same story.
+        classpath(libs.udytils.atlasGradlePlugin)
     }
 }
 
@@ -29,3 +32,9 @@ plugins {
     alias(libs.plugins.kotlinKsp) apply false
     alias(libs.plugins.kotlinSerialization) apply false
 }
+
+// Applied here, not in the plugins block: the root project's plugins block cannot
+// resolve version-free plugin ids from the buildscript classpath — that only works
+// in subprojects. Subproject plugins (architecture, postgres) use alias() because
+// their plugins block inherits the root classpath; the root must apply() directly.
+apply(plugin = "dev.isaacudy.udytils.atlas")

--- a/docs/template-migrations/2026-08-19-ui-atlas-plugin.md
+++ b/docs/template-migrations/2026-08-19-ui-atlas-plugin.md
@@ -1,0 +1,57 @@
+# Wire the UI atlas Gradle plugin
+
+The template now ships the `dev.isaacudy.udytils.atlas` Gradle plugin, applied at the root project.
+It registers `generateUiAtlas`: scans the repo for Enro `@NavigationDestination` nodes, `.open()`
+edges, and Paparazzi goldens, then writes `build/ui-atlas/` with an interactive `index.html`, a
+machine-readable `manifest.json`, and copied golden images.
+
+## Detection
+
+```bash
+grep -q "udytils.atlas" build.gradle.kts   # plugin already applied?
+```
+
+## Migration
+
+1. **Bump `embedded-udytils`** past the atlas commit (`fbd51bf` or later).
+
+2. **`settings.gradle.kts`** — add two substitutions to the `embedded-udytils` `dependencySubstitution` block:
+   ```kotlin
+   substitute(module("dev.isaacudy.udytils:atlas-core")).using(project(":atlas-core"))
+   substitute(module("dev.isaacudy.udytils:atlas-gradle-plugin")).using(project(":atlas-gradle-plugin"))
+   ```
+
+3. **`gradle/libs.versions.toml`** — add two catalog entries:
+   ```toml
+   # [libraries]
+   udytils-atlasGradlePlugin = { module = "dev.isaacudy.udytils:atlas-gradle-plugin" }
+
+   # [plugins]
+   udytilsAtlas = { id = "dev.isaacudy.udytils.atlas" }
+   ```
+
+4. **Root `build.gradle.kts`** — add the classpath dependency and apply the plugin. The root
+   project's `plugins {}` block cannot resolve version-free plugin ids from the buildscript
+   classpath (subproject `plugins {}` blocks can, because they inherit the root classpath); use
+   `apply(plugin = ...)` after the `plugins {}` block instead:
+   ```kotlin
+   buildscript {
+       dependencies {
+           classpath(libs.udytils.atlasGradlePlugin)
+       }
+   }
+
+   // after the plugins { } block:
+   apply(plugin = "dev.isaacudy.udytils.atlas")
+   ```
+
+5. The `ukpt-ui-atlas` skill arrives via the template file sync.
+
+## Verification
+
+```bash
+./gradlew generateUiAtlas
+```
+
+The task must succeed. If the project has Enro destinations with recorded Paparazzi goldens, the
+output should report nonzero nodes and goldens. Open `build/ui-atlas/index.html` to confirm.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -100,6 +100,7 @@ udytils-postgres-gradlePlugin = { module = "dev.isaacudy.udytils:postgres-gradle
 udytils-architectureCore = { module = "dev.isaacudy.udytils:architecture-core" }
 udytils-architectureAnnotations = { module = "dev.isaacudy.udytils:architecture-annotations" }
 udytils-architectureGradlePlugin = { module = "dev.isaacudy.udytils:architecture-gradle-plugin" }
+udytils-atlasGradlePlugin = { module = "dev.isaacudy.udytils:atlas-gradle-plugin" }
 
 # Build-logic dependencies (gradle plugin classpath artifacts)
 kotlin-gradlePlugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
@@ -127,4 +128,5 @@ paparazzi = { id = "app.cash.paparazzi", version.ref = "paparazzi" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 # Version-less: resolved from the root buildscript classpath (composite-substituted), not a repository.
 udytilsArchitecture = { id = "dev.isaacudy.udytils.architecture" }
+udytilsAtlas = { id = "dev.isaacudy.udytils.atlas" }
 udytilsPostgres = { id = "dev.isaacudy.udytils.postgres" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -88,5 +88,7 @@ includeBuild("embedded-udytils") {
         substitute(module("dev.isaacudy.udytils:architecture-core")).using(project(":architecture-core"))
         substitute(module("dev.isaacudy.udytils:architecture-annotations")).using(project(":architecture-annotations"))
         substitute(module("dev.isaacudy.udytils:architecture-gradle-plugin")).using(project(":architecture-gradle-plugin"))
+        substitute(module("dev.isaacudy.udytils:atlas-core")).using(project(":atlas-core"))
+        substitute(module("dev.isaacudy.udytils:atlas-gradle-plugin")).using(project(":atlas-gradle-plugin"))
     }
 }


### PR DESCRIPTION
Adopts the new udytils UI-atlas Gradle plugin ([udytils#25](https://github.com/isaac-udy/udytils/pull/25), now merged) so the template — and every downstream project after its next update — gets `./gradlew generateUiAtlas`: an interactive `index.html` map of every screen, its Paparazzi golden variants, and the navigation edges between screens, plus a machine-readable `manifest.json` for agent orientation.

## Changes

- **Submodule**: `embedded-udytils` pinned to `9c7824e` (the atlas merge commit on main).
- **Composite wiring**, following the postgres/architecture precedent: substitutions for `atlas-core`/`atlas-gradle-plugin` in `settings.gradle.kts`, catalog entries in `libs.versions.toml`, plugin on the root buildscript classpath.
- **Root application**: `apply(plugin = "dev.isaacudy.udytils.atlas")` — not `alias(...)` in the `plugins {}` block, because a root project's plugins block cannot resolve version-free plugin ids from its own buildscript classpath (subprojects can; the comment in the build file records the constraint).
- **Skill**: `ukpt-ui-atlas` — how to generate the atlas, and the `manifest.json` schema agents should read to orient before UI work instead of grepping for destinations.
- **UKPT.md**: short UI-atlas section.
- **Template versioning**: `templateVersion` → `2026-08-19` with migration entry `docs/template-migrations/2026-08-19-ui-atlas-plugin.md` walking downstream projects through the wiring.

## Verification

- `generateUiAtlas`: 3 nodes / 1 edge / 4 goldens on the template, `UP-TO-DATE` on rerun with the configuration cache reused (stored + reused cleanly — the plugin holds no `Project` reference and discovers roots at execution time).
- `validateTemplate` passes (skill metadata, links, migration ordering).
- `:app:client:desktop:compileKotlin` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)