### PR TITLE
Restructure UKPT.md for progressive disclosure

### DIFF
--- a/.agents/skills/ukpt-feature-slice/SKILL.md
+++ b/.agents/skills/ukpt-feature-slice/SKILL.md
@@ -54,7 +54,7 @@ whatever the project was renamed to downstream — read `platform/client/design`
      `<name>ServerDependencies` to its `modules(...)` list once the feature has something to bind.
      Teaching that host to *serve* urpc is the `ukpt-urpc-service` skill's job — do it when the
      feature gets its first service, not at scaffold time.
-6. **Verify** — the six-target compile sweep (see UKPT.md §Compiling), record + verify Paparazzi for the new client
+6. **Verify** — the six-target compile sweep (see the `ukpt-verify` skill), record + verify Paparazzi for the new client
    module, and `./gradlew :platform:common:architecture:verifyArchitecture`. If the feature has web UI, run
    the `ukpt-verify-web` skill — a forgotten `viewModelOf` only crashes at runtime on wasm, invisible to compile.
 

--- a/.agents/skills/ukpt-new-project/SKILL.md
+++ b/.agents/skills/ukpt-new-project/SKILL.md
@@ -110,7 +110,7 @@ project's names. Keep it accurate if the project is ever re-branded.
 
 ## 5. Verify
 
-Run the full verification before the first commit — the six-target compile sweep (see UKPT.md §Compiling)
+Run the full verification before the first commit — the six-target compile sweep (see the `ukpt-verify` skill)
 first, then the project-specific checks:
 
 ```

--- a/.agents/skills/ukpt-run/SKILL.md
+++ b/.agents/skills/ukpt-run/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ukpt-run
+description: >-
+  Run or launch the app on any platform — Desktop, Android, Web, iOS, and
+  Server — plus the embedded dev-Postgres and dev database setup (data location,
+  env switches, wipe, seeding). Use when launching the app or working with the
+  dev database.
+---
+
+# ukpt-run
+
+Per-platform run commands and the server's dev-database setup.
+
+Identifiers below use the template's UKPT identity (env vars like `UKPT_DEV_DB`, packages like `feature.ukpt`). In projects created from the template these are renamed to the project's own identity — check `.ukpt/template.json` for the rename map.
+
+## Desktop
+
+```
+./gradlew :app:client:desktop:run
+```
+
+## Server (Ktor)
+
+```
+./gradlew :app:server:run
+```
+Boots against an embedded Postgres that keeps its data between runs; see Dev database below.
+
+## Web (dev server)
+
+```
+./gradlew :app:client:web:wasmJsBrowserDevelopmentRun --no-configuration-cache
+```
+Open the served URL. The `--no-configuration-cache` flag is required (upstream `KotlinWebpack`
+limitation).
+
+## Android
+
+Run from Android Studio, or:
+```
+./gradlew :app:client:android:installDebug
+```
+to a connected device/emulator.
+
+## iOS
+
+Open `app/client/ios/iosApp.xcodeproj` in Xcode and run. There is no Gradle command: the Xcode
+project's "Compile Kotlin framework" build phase invokes
+`:app:client:common:embedAndSignAppleFrameworkForXcode`, which builds `App.framework` and puts it
+where the linker expects.
+
+Simulator builds are **Apple Silicon only** — `:app:client:common` declares `iosArm64` +
+`iosSimulatorArm64`, so the Xcode project excludes the `x86_64` simulator slice. Add an `iosX64()`
+target if you need Intel Macs.
+
+## Dev database
+
+Server persistence uses the `dev.isaacudy.udytils.postgres` toolkit (Exposed + Flyway); conventions
+are in [docs/serverdata.md](../../../platform/common/architecture/docs/serverdata.md) (the
+`server.data.storage` section). `:platform:server:postgres` owns the Flyway migrations
+(`src/main/resources/db/migration/`, empty until the first schema) and the codegen that turns them
+into Exposed `Table`/`Row` sources; `:platform:server:development` owns the dev-database scenarios.
+
+`./gradlew :app:server:run` needs no database of your own — it starts an embedded Postgres, migrates
+it, seeds a brand-new one from `DefaultScenario`, and prints a banner saying where it is. The data
+lives in `app/server/build/dev-postgres/pg<major>/` and survives restarts (`clean` wipes it, as does
+`./gradlew :app:server:wipeDevDatabase`).
+
+### Environment switches
+
+- `UKPT_DEV_DB` — `embedded` (persistent, the `run` default), `ephemeral` (a throwaway cluster on a
+  random port), or anything else to connect to a real Postgres from `POSTGRES_URL` /
+  `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_MAX_POOL_SIZE`. Set it in the invoking
+  environment and `run` yields to you.
+- `UKPT_DEV_DB_DIR` — where a persistent cluster lives; `run` points it at the build directory.
+- `UKPT_DEV_SCENARIO` — names a `DevScenarios` entry to seed a **new** cluster with. Seeding is
+  once-per-cluster; asking for a scenario over existing data fails rather than inserting on top.
+- `PORT` — what the server listens on, default 8080.

--- a/.agents/skills/ukpt-run/SKILL.md
+++ b/.agents/skills/ukpt-run/SKILL.md
@@ -9,9 +9,7 @@ description: >-
 
 # ukpt-run
 
-Per-platform run commands and the server's dev-database setup.
-
-Identifiers below use the template's UKPT identity (env vars like `UKPT_DEV_DB`, packages like `feature.ukpt`). In projects created from the template these are renamed to the project's own identity — check `.ukpt/template.json` for the rename map.
+Identifiers here use the template's UKPT identity (`UKPT_DEV_DB`, `feature.ukpt`); projects rename these — the map is in `.ukpt/template.json`.
 
 ## Desktop
 
@@ -36,11 +34,8 @@ limitation).
 
 ## Android
 
-Run from Android Studio, or:
-```
-./gradlew :app:client:android:installDebug
-```
-to a connected device/emulator.
+Run from Android Studio, or `./gradlew :app:client:android:installDebug` to a connected
+device/emulator.
 
 ## iOS
 
@@ -69,9 +64,8 @@ lives in `app/server/build/dev-postgres/pg<major>/` and survives restarts (`clea
 ### Environment switches
 
 - `UKPT_DEV_DB` — `embedded` (persistent, the `run` default), `ephemeral` (a throwaway cluster on a
-  random port), or anything else to connect to a real Postgres from `POSTGRES_URL` /
-  `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_MAX_POOL_SIZE`. Set it in the invoking
-  environment and `run` yields to you.
+  random port), or any other value to connect to an external Postgres via `POSTGRES_URL` /
+  `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_MAX_POOL_SIZE`.
 - `UKPT_DEV_DB_DIR` — where a persistent cluster lives; `run` points it at the build directory.
 - `UKPT_DEV_SCENARIO` — names a `DevScenarios` entry to seed a **new** cluster with. Seeding is
   once-per-cluster; asking for a scenario over existing data fails rather than inserting on top.

--- a/.agents/skills/ukpt-run/agents/openai.yaml
+++ b/.agents/skills/ukpt-run/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Run UKPT App"
+  short_description: "Run the app on any platform or start the dev server"
+  default_prompt: "Use $ukpt-run to launch the app on the target platform."

--- a/.agents/skills/ukpt-server-packaging/SKILL.md
+++ b/.agents/skills/ukpt-server-packaging/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: ukpt-server-packaging
+description: >-
+  Build, verify, and deploy the server fat jar — buildFatJar, runtime
+  service-file collision checks, the Shadow mergeServiceFiles distrust warning,
+  and smokeTestFatJar. Use when packaging or deploying the server.
+---
+
+# ukpt-server-packaging
+
+`./gradlew :app:server:buildFatJar` builds the deployable, minus the dev database: Zonky's embedded
+Postgres, its per-platform binaries and `:platform:server:development` are filtered out of the
+Shadow jar (`ukpt.server-packaging`). `run` and the tests are unaffected — they use the normal
+runtime classpath.
+
+## Service-file collision check
+
+Two checks exist because a fat jar can silently drop things.
+
+`verifyRuntimeServiceFiles` (part of `check`, and gates `shadowJar`) fails when two runtime
+dependencies declare the same `META-INF/services` path, since only one copy survives packaging —
+`flyway-core` and `flyway-database-postgresql` do, which is why
+`app/server/src/main/resources/META-INF/services/` holds a hand-merged copy (its README says when to
+regenerate it).
+
+**Do not trust Shadow's `mergeServiceFiles()`**: it is called and, on 9.1.0, does not merge —
+verify by extracting the file from a built jar.
+
+## Smoke test
+
+```
+./gradlew :app:server:smokeTestFatJar
+```
+Boots the built jar the way a container would, on an OS-assigned port against a throwaway database,
+and asserts it migrates and answers. Nothing else exercises the jar itself.

--- a/.agents/skills/ukpt-server-packaging/SKILL.md
+++ b/.agents/skills/ukpt-server-packaging/SKILL.md
@@ -2,8 +2,8 @@
 name: ukpt-server-packaging
 description: >-
   Build, verify, and deploy the server fat jar — buildFatJar, runtime
-  service-file collision checks, the Shadow mergeServiceFiles distrust warning,
-  and smokeTestFatJar. Use when packaging or deploying the server.
+  service-file collision checks, Shadow 9.1.0's mergeServiceFiles() silently not
+  merging, and smokeTestFatJar. Use when packaging or deploying the server.
 ---
 
 # ukpt-server-packaging
@@ -15,11 +15,9 @@ runtime classpath.
 
 ## Service-file collision check
 
-Two checks exist because a fat jar can silently drop things.
-
 `verifyRuntimeServiceFiles` (part of `check`, and gates `shadowJar`) fails when two runtime
-dependencies declare the same `META-INF/services` path, since only one copy survives packaging —
-`flyway-core` and `flyway-database-postgresql` do, which is why
+dependencies declare the same `META-INF/services` path, since only one copy survives packaging.
+`flyway-core` and `flyway-database-postgresql` collide;
 `app/server/src/main/resources/META-INF/services/` holds a hand-merged copy (its README says when to
 regenerate it).
 

--- a/.agents/skills/ukpt-server-packaging/agents/openai.yaml
+++ b/.agents/skills/ukpt-server-packaging/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "UKPT Server Packaging"
+  short_description: "Build and verify the server fat jar"
+  default_prompt: "Use $ukpt-server-packaging to build and verify the server fat jar."

--- a/.agents/skills/ukpt-template-update/SKILL.md
+++ b/.agents/skills/ukpt-template-update/SKILL.md
@@ -124,7 +124,7 @@ Projects tweak and extend their rule catalogs. Never treat the catalog as templa
 
 ## 7. Verify
 
-Run the six-target compile sweep (see UKPT.md §Compiling), then:
+Run the six-target compile sweep (see the `ukpt-verify` skill), then:
 
 ```
 ./gradlew :platform:common:architecture:verifyArchitecture

--- a/.agents/skills/ukpt-ui-atlas/SKILL.md
+++ b/.agents/skills/ukpt-ui-atlas/SKILL.md
@@ -24,7 +24,7 @@ Output lands in `build/ui-atlas/`:
 - `images/` — copied golden PNGs.
 
 Goldens must exist before generating. If screens are missing images, run `recordPaparazzi` for the
-relevant client modules first (see [UKPT.md](../../../UKPT.md) §Testing).
+relevant client modules first (see the `ukpt-verify` skill).
 
 ## Agent orientation via `manifest.json`
 

--- a/.agents/skills/ukpt-urpc-service/SKILL.md
+++ b/.agents/skills/ukpt-urpc-service/SKILL.md
@@ -28,7 +28,7 @@ also stands up the host (Step 5). Copy-paste skeletons are in `templates.md`.
    Function shapes — each takes 0 or 1 param: `suspend fun f(req): Res` (unary), `fun f(req): Flow<Res>`
    (server stream), `fun f(reqs: Flow<Req>): Flow<Res>` (bidi). Errors propagate as **thrown exceptions**;
    the return type only models success. **No `:api` build edit** — urpc KSP is already wired per-target.
-2. **Generate** — run the compile sweep (see UKPT.md §Compiling) so KSP emits `<Name>ServiceUrpcBinding`
+2. **Generate** — run the compile sweep (see the `ukpt-verify` skill) so KSP emits `<Name>ServiceUrpcBinding`
    + the client before Steps 3–4 reference them.
 3. **Implement** (`:server`, `feature.<name>.server.services`): `internal class <Name>ServiceImpl(...) : <Name>Service`
    (the `ServerServices.ServiceImpl` construct). A ServiceImpl is an **entry point**: it answers the

--- a/.agents/skills/ukpt-verify/SKILL.md
+++ b/.agents/skills/ukpt-verify/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: ukpt-verify
+description: >-
+  Compile and build every platform (client + server) and run tests — the
+  six-target compile sweep, architecture rule verification, validateTemplate and
+  template integrity, Paparazzi snapshot golden recording/verification,
+  per-module unit tests, iOS compile caveats, and --no-configuration-cache
+  requirements. Use after making changes to verify correctness across all
+  targets.
+---
+
+# ukpt-verify
+
+Identifiers below use the template's UKPT identity (symbols like `UkptPreviewFrame`, packages like `feature.ukpt`). In projects created from the template these are renamed to the project's own identity — check `.ukpt/template.json` for the rename map.
+
+After making changes, compile every platform and run the relevant tests. For web/wasm
+bundle and runtime verification, use the `ukpt-verify-web` skill — it covers the four
+wasm-only failure modes that compilation misses.
+
+## Compiling
+
+Compile every platform (client + server) to verify correctness:
+```
+./gradlew :app:client:android:compileDebugKotlin \
+          :app:client:desktop:compileKotlin \
+          :app:client:web:compileKotlinWasmJs \
+          :app:client:common:compileKotlinIosArm64 \
+          :app:client:common:compileKotlinIosSimulatorArm64 \
+          :app:server:compileKotlin
+```
+The common module's Android / JVM / wasm targets compile transitively via the per-platform app
+modules; the iOS targets are built directly from `:app:client:common`. There is no
+`:app:client:ios` **Gradle** module — the iOS app is an Xcode project at `app/client/ios`, which
+consumes `App.framework` from `:app:client:common`. Compiling the iOS targets does **not** exercise
+the app: the Compose/Enro entry point (`iosMain/MainViewController.kt`) is only executed when the
+Xcode app runs, so a change to it must be verified by actually launching the app.
+
+**Web (wasm) caveat — compiling is not enough.** `compileKotlinWasmJs` only type-checks; it does
+**not** catch failures at wasm bundle time or runtime. For any web change, use the `ukpt-verify-web`
+skill to bundle and serve the app in a browser.
+
+## Configuration cache
+
+`--no-configuration-cache` is **required** on these tasks:
+
+- **`wasmJsBrowser*` tasks** (`wasmJsBrowserDevelopmentWebpack`, `wasmJsBrowserDevelopmentRun`): the
+  Kotlin plugin's `KotlinWebpack` task holds a `Project` reference and an unserializable
+  `SoftReference`, so it cannot be stored in the configuration cache (upstream). Everything else,
+  including `compileKotlinWasmJs`, is cache-clean.
+- **Paparazzi tasks** (`recordPaparazzi`, `verifyPaparazzi`): under the configuration cache the R
+  class is dropped from the test runtime classpath and every snapshot test dies with
+  `ClassNotFoundException: <module>.R`.
+- **`allTests` on client modules**: a client module's `allTests` includes the snapshot host test, so
+  it needs `--no-configuration-cache` too (same R-class failure as above).
+
+## Testing
+
+### Template integrity
+
+`./gradlew validateTemplate` checks the marker and migration ordering/sections, shared agent
+guidance, Codex skill metadata, Claude compatibility links, and that every file path, markdown link
+and architecture rule id a skill cites still resolves — skills describe code they don't contain, so
+moving code is what makes them rot. `./gradlew -p build-logic test` runs the validator and safe
+project-rename planner's unit tests.
+
+### Architecture rules
+
+`./gradlew :platform:common:architecture:verifyArchitecture` is a standalone task that always
+re-executes (no `--rerun-tasks` needed; the module's plain `test` task runs nothing — the test
+classes are plugin-generated from the `UkptArchitecture` definition, not checked in). The suite
+reports **one nested test per rule** (`<Layer> > <Construct> > <rule>`), so a failure names the
+exact rule.
+
+After changing a rule or an examples file, regenerate the generated documentation (README +
+`docs/`):
+```
+./gradlew :platform:common:architecture:updateArchitectureDocumentation
+```
+
+### UI snapshots
+
+UI snapshots are preview-driven: every `@Preview` composable is discovered by
+`PreviewSnapshotTest` and snapshotted with Paparazzi (`ClientUi.Composable.screenContentPreview`
+requires a `@Preview` per ScreenContent). Screen previews wrap their content in the design module's
+`UkptPreviewFrame`, and each module's `PreviewSnapshotTest` renders in `RenderingMode.SHRINK`,
+cropping the golden to that frame — so a screen golden reads as a device screenshot, not a render
+padded to the harness canvas.
+
+Record then verify goldens, per client module:
+```
+./gradlew :feature:core:client:recordPaparazzi --no-configuration-cache
+./gradlew :feature:core:client:verifyPaparazzi --no-configuration-cache
+```
+
+Goldens are **directory-grouped** by the preview's declaring package and function name, so a preview
+in `feature.ukpt.client.ui` lands at
+`src/androidHostTest/snapshots/images/feature/ukpt/client/ui/UkptScreenPreview.png`.
+`DirectorySnapshotHandler` (a custom Paparazzi `SnapshotHandler`) implements that layout; stock
+Paparazzi can only emit one long flat filename per golden. Two previews resolving to the same golden
+path fail fast at test-parameter creation rather than silently overwriting one another.
+
+### Unit tests
+
+Per KMP module via the umbrella task, e.g.:
+```
+./gradlew :feature:core:api:allTests :feature:core:client:allTests
+```
+A client module's `allTests` includes the snapshot host test, so it needs `--no-configuration-cache`
+(see Configuration cache above).
+
+Server coverage lives in **two** modules:
+```
+./gradlew :feature:core:server:test :app:server:test
+```
+The feature module holds nearly all of it; `:app:server:test` alone runs only the shell's own tests.

--- a/.agents/skills/ukpt-verify/SKILL.md
+++ b/.agents/skills/ukpt-verify/SKILL.md
@@ -11,10 +11,9 @@ description: >-
 
 # ukpt-verify
 
-Identifiers below use the template's UKPT identity (symbols like `UkptPreviewFrame`, packages like `feature.ukpt`). In projects created from the template these are renamed to the project's own identity — check `.ukpt/template.json` for the rename map.
+Identifiers here use the template's UKPT identity (`UkptPreviewFrame`, `feature.ukpt`); projects rename these — the map is in `.ukpt/template.json`.
 
-After making changes, compile every platform and run the relevant tests. For web/wasm
-bundle and runtime verification, use the `ukpt-verify-web` skill — it covers the four
+For web/wasm bundle and runtime verification, use the `ukpt-verify-web` skill — it covers the four
 wasm-only failure modes that compilation misses.
 
 ## Compiling
@@ -59,9 +58,9 @@ skill to bundle and serve the app in a browser.
 
 `./gradlew validateTemplate` checks the marker and migration ordering/sections, shared agent
 guidance, Codex skill metadata, Claude compatibility links, and that every file path, markdown link
-and architecture rule id a skill cites still resolves — skills describe code they don't contain, so
-moving code is what makes them rot. `./gradlew -p build-logic test` runs the validator and safe
-project-rename planner's unit tests.
+and architecture rule ID a skill cites still resolves. Skills cite code they don't contain, so
+moving code silently invalidates them — `validateTemplate` catches that.
+`./gradlew -p build-logic test` runs the validator and safe project-rename planner's unit tests.
 
 ### Architecture rules
 
@@ -95,9 +94,8 @@ Record then verify goldens, per client module:
 Goldens are **directory-grouped** by the preview's declaring package and function name, so a preview
 in `feature.ukpt.client.ui` lands at
 `src/androidHostTest/snapshots/images/feature/ukpt/client/ui/UkptScreenPreview.png`.
-`DirectorySnapshotHandler` (a custom Paparazzi `SnapshotHandler`) implements that layout; stock
-Paparazzi can only emit one long flat filename per golden. Two previews resolving to the same golden
-path fail fast at test-parameter creation rather than silently overwriting one another.
+`DirectorySnapshotHandler` implements this layout (stock Paparazzi only emits flat filenames). Two
+previews resolving to the same golden path fail fast at test-parameter creation.
 
 ### Unit tests
 

--- a/.agents/skills/ukpt-verify/agents/openai.yaml
+++ b/.agents/skills/ukpt-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Verify UKPT Build"
+  short_description: "Compile all platforms and run tests"
+  default_prompt: "Use $ukpt-verify to compile every platform and run the relevant tests."

--- a/.claude/skills/ukpt-run
+++ b/.claude/skills/ukpt-run
@@ -1,0 +1,1 @@
+../../.agents/skills/ukpt-run

--- a/.claude/skills/ukpt-server-packaging
+++ b/.claude/skills/ukpt-server-packaging
@@ -1,0 +1,1 @@
+../../.agents/skills/ukpt-server-packaging

--- a/.claude/skills/ukpt-verify
+++ b/.claude/skills/ukpt-verify
@@ -1,0 +1,1 @@
+../../.agents/skills/ukpt-verify

--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-08-19"
+  "templateVersion": "2026-08-19.1"
 }

--- a/UKPT.md
+++ b/UKPT.md
@@ -10,17 +10,17 @@ This file holds operational guidance (commands, toolchain, submodules) and point
 
 ## Template versioning
 
-Downstream projects update from this template with the `ukpt-template-update` skill, driven by `.ukpt/template.json` and [`docs/template-migrations/`](./docs/template-migrations/README.md). When a change affects code that only exists downstream — a convention change, an architecture rule added/renamed/tightened, a structural change — bump `templateVersion` in `.ukpt/template.json` and add a migration entry in the same commit. Version bumps and template-owned file changes don't need an entry. Before committing any template change, run `./gradlew validateTemplate`.
+Downstream projects update via the `ukpt-template-update` skill. When a change affects code that only exists downstream — a convention change, an architecture rule added/renamed/tightened, a structural change — bump `templateVersion` in [`.ukpt/template.json`](./.ukpt/template.json) and add a [`docs/template-migrations/`](./docs/template-migrations/README.md) entry in the same commit. Version bumps and template-owned file changes don't need an entry. Before committing any template change, run `./gradlew validateTemplate`.
 
 ## Architecture
 
 Follow the rules in [`platform/common/architecture/README.md`](./platform/common/architecture/README.md), enforced by Konsist tests. Orientation:
 
 - **Module groups**: `:app` (executable shells + DI wiring), `:feature` (vertical slices — `:api` contract, `:client` UI/logic, `:server` implementation), `:platform` (reusable infrastructure).
-- **Feature packages are side-first**: `feature.<name>` holds the shared wire vocabulary; below it a side (`client`/`server`), then a layer — `client.ui`, `client.domain`, `client.data` / `server.services` (the `@Urpc` contract in `:api`, its `ServiceImpl` on `:server`), `server.domain`, `server.data`. Publication to `:api` is a module move that never changes the package.
+- **Feature packages are side-first**: `feature.<name>` holds the shared wire vocabulary; below it a side, then a layer — client: `client.ui`, `client.domain`, `client.data`; server: `server.services` (the `@Urpc` contract in `:api`, its `ServiceImpl` on `:server`), `server.domain`, `server.data`. Publication to `:api` is a module move that never changes the package.
 - The rules are a machine-readable **object catalog** in [`platform/common/architecture/src/main/kotlin/architecture/rules/`](./platform/common/architecture/src/main/kotlin/architecture/rules) (a `RuleGroup` object per layer in its own sub-package; one top-level `Construct<Group>` object per construct in its own file, listed in the group's `constructs`; a rule per property; the engine is the `dev.isaacudy.udytils:architecture-core` artifact from `embedded-udytils`). Rules shared by the client/server twins of one construct are declared once on abstract base classes in [`rules/shared/`](./platform/common/architecture/src/main/kotlin/architecture/rules/shared) and instantiated per side. Every rule has a stable **path ID** — the object/property path, e.g. `ClientDomain.UseCase.noOverridingDefaults` — and an enforcement tag; [`docs/rule-index.md`](./platform/common/architecture/docs/rule-index.md) lists them all.
 - The README and everything under `platform/common/architecture/docs/` are **generated**: rule statements and narrative come from `@Describe` annotations in the catalog; example blocks come from `<Construct>.examples.md` files in the group's package. Edit the catalog or an examples file — never the generated files — then regenerate with `./gradlew :platform:common:architecture:updateArchitectureDocumentation`.
-- Exempt a declaration that genuinely can't conform with `@ArchitectureException(ruleIds = ["..."])` ([docs/exceptions.md](./platform/common/architecture/docs/exceptions.md)), only with human sign-off.
+- Exemptions require human sign-off: `@ArchitectureException(ruleIds = ["..."])` ([docs/exceptions.md](./platform/common/architecture/docs/exceptions.md)).
 - Comment discipline: see [docs/code-comments.md](./docs/code-comments.md) — a comment must say something the code cannot.
 
 ## Toolchain & constraints
@@ -46,21 +46,21 @@ Agents often run several at a time — subagents in one session, plus other sess
 In order of leverage:
 
 1. **Don't build what you don't need.** A docs, comment, or guidance-only change has no runtime surface — there is nothing a compile would verify. Skip it.
-2. **Scope the build to the change.** Prefer one module's task (`:feature:core:client:compileKotlin`) over the full six-target sweep below. `verifyArchitecture` and `validateTemplate` are cheap; `assembleDebug`, the full sweep, `recordPaparazzi`, and anything Kotlin/Native are not. Never `clean` unless the task genuinely depends on it — the configuration and build caches are on, and `clean` discards exactly what makes a rebuild cheap.
+2. **Scope the build to the change.** Prefer one module's task (`:feature:core:client:compileKotlin`) over the full six-target sweep (see `ukpt-verify`). `verifyArchitecture` and `validateTemplate` are cheap; `assembleDebug`, the full sweep, `recordPaparazzi`, and anything Kotlin/Native are not. Never `clean` unless the task genuinely depends on it — the configuration and build caches are on, and `clean` discards exactly what makes a rebuild cheap.
 3. **Don't run heavy builds concurrently.** When orchestrating subagents, let them read, analyse, and edit in parallel — that part is cheap — then run compilation and verification one at a time. Parallelism belongs in the editing phase, not the build phase.
 4. **Throttle a background build** with `--max-workers=2`. Use a small *fixed* cap rather than a fraction of the core count: you can't know how many agents are running, and a per-agent fraction still multiplies by the number of agents, whereas a fixed cap bounds what each one contributes. A **foreground** build — one the user is waiting on — should not be throttled; it should finish fast.
 5. **Never override daemon memory on an invocation.** Passing `org.gradle.jvmargs` or `kotlin.daemon.jvmargs` on the command line means the running daemon no longer matches, so a new one is forked — asking for less memory gets you more of it. Those belong in `gradle.properties`, one value shared by everyone. For the same reason keep flags identical across agents doing the same kind of work: daemons are matched on their JVM args, so inconsistent flags fragment the daemon pool.
 
 ## Verification
 
-After changes, compile every platform (client + server), not just the touched module — use the `ukpt-verify` skill for the full sweep and test commands. Paparazzi and `wasmJsBrowser*` tasks require `--no-configuration-cache`; the skill documents which tasks and why.
+After changes, compile every platform (client + server), not just the touched module — the `ukpt-verify` skill has the full sweep and test commands. Paparazzi and `wasmJsBrowser*` tasks require `--no-configuration-cache`.
 
 ## Reference
 
-- **Running the app**: `ukpt-run` — per-platform run commands, the dev database (embedded Postgres, env switches, seeding, wipe).
-- **Web verification**: `ukpt-verify-web` — bundle and runtime gates for the four wasm-only failure modes.
-- **UI atlas**: `ukpt-ui-atlas` — `./gradlew generateUiAtlas`, manifest schema, agent orientation.
-- **Server packaging**: `ukpt-server-packaging` — fat jar build, service-file collision checks, smoke test.
-- **Feature scaffolding**: `ukpt-feature-slice` — scaffold `:feature:<name>:{api,client,server}`.
-- **urpc services**: `ukpt-urpc-service` — add or change a client/server `@Urpc` service end-to-end.
-- **Design system**: `ukpt-design-system` — establish or extend the project's design system.
+- `ukpt-run` — per-platform run commands, dev database setup and env switches.
+- `ukpt-verify-web` — wasm bundle and runtime verification.
+- `ukpt-ui-atlas` — `./gradlew generateUiAtlas`, manifest schema.
+- `ukpt-server-packaging` — fat jar build, service-file checks, smoke test.
+- `ukpt-feature-slice` — scaffold `:feature:<name>:{api,client,server}`.
+- `ukpt-urpc-service` — add or change a `@Urpc` service end-to-end.
+- `ukpt-design-system` — design system tokens and primitives.

--- a/UKPT.md
+++ b/UKPT.md
@@ -10,23 +10,17 @@ This file holds operational guidance (commands, toolchain, submodules) and point
 
 ## Template versioning
 
-Downstream projects update from this template with the `ukpt-template-update` skill, driven by `.ukpt/template.json` and [`docs/template-migrations/`](./docs/template-migrations/README.md). When a change affects code that only exists downstream — a convention change, an architecture rule added/renamed/tightened, a structural change — bump `templateVersion` in `.ukpt/template.json` and add a migration entry in the same commit (see the migrations README for the format). Version bumps and template-owned file changes don't need an entry.
-
-Before committing a template change, run `./gradlew validateTemplate`. It checks the marker and
-migration ordering/sections, shared agent guidance, Codex skill metadata, Claude compatibility
-links, and that every file path, markdown link and architecture rule id a skill cites still
-resolves — skills describe code they don't contain, so moving code is what makes them rot. The
-validator and rename-planner unit tests run with `./gradlew -p build-logic test`.
+Downstream projects update from this template with the `ukpt-template-update` skill, driven by `.ukpt/template.json` and [`docs/template-migrations/`](./docs/template-migrations/README.md). When a change affects code that only exists downstream — a convention change, an architecture rule added/renamed/tightened, a structural change — bump `templateVersion` in `.ukpt/template.json` and add a migration entry in the same commit. Version bumps and template-owned file changes don't need an entry. Before committing any template change, run `./gradlew validateTemplate`.
 
 ## Architecture
 
 Follow the rules in [`platform/common/architecture/README.md`](./platform/common/architecture/README.md), enforced by Konsist tests. Orientation:
 
 - **Module groups**: `:app` (executable shells + DI wiring), `:feature` (vertical slices — `:api` contract, `:client` UI/logic, `:server` implementation), `:platform` (reusable infrastructure).
-- **Feature packages are side-first**: the root `feature.<name>` holds the shared wire vocabulary (the models, exceptions and constants both sides speak); below it a side (`client`/`server`), then a layer — `client.ui`, `client.domain`, `client.data` on one side and `server.services` (the `@Urpc` contract in `:api`, its `ServiceImpl` on `:server`), `server.domain`, `server.data` on the other. Publication to `:api` is a module move that never changes the package.
+- **Feature packages are side-first**: `feature.<name>` holds the shared wire vocabulary; below it a side (`client`/`server`), then a layer — `client.ui`, `client.domain`, `client.data` / `server.services` (the `@Urpc` contract in `:api`, its `ServiceImpl` on `:server`), `server.domain`, `server.data`. Publication to `:api` is a module move that never changes the package.
 - The rules are a machine-readable **object catalog** in [`platform/common/architecture/src/main/kotlin/architecture/rules/`](./platform/common/architecture/src/main/kotlin/architecture/rules) (a `RuleGroup` object per layer in its own sub-package; one top-level `Construct<Group>` object per construct in its own file, listed in the group's `constructs`; a rule per property; the engine is the `dev.isaacudy.udytils:architecture-core` artifact from `embedded-udytils`). Rules shared by the client/server twins of one construct are declared once on abstract base classes in [`rules/shared/`](./platform/common/architecture/src/main/kotlin/architecture/rules/shared) and instantiated per side. Every rule has a stable **path ID** — the object/property path, e.g. `ClientDomain.UseCase.noOverridingDefaults` — and an enforcement tag; [`docs/rule-index.md`](./platform/common/architecture/docs/rule-index.md) lists them all.
-- The README and everything under `platform/common/architecture/docs/` are **generated**: rule statements and narrative come from `@Describe` annotations in the catalog itself; example blocks come from `<Construct>.examples.md` files in the group's package (e.g. `rules/clientdata/Repository.examples.md` and its `rules/serverdata/` twin). The generator compiles a fixed per-layer structure (description → Requirements → Rules → Guidance → Examples). Edit the catalog or an examples file — never the generated files — then regenerate (see Testing).
-- Exempt a declaration that genuinely can't conform with `@ArchitectureException(ruleIds = ["…"])` ([docs/exceptions.md](./platform/common/architecture/docs/exceptions.md)), only with human sign-off.
+- The README and everything under `platform/common/architecture/docs/` are **generated**: rule statements and narrative come from `@Describe` annotations in the catalog; example blocks come from `<Construct>.examples.md` files in the group's package. Edit the catalog or an examples file — never the generated files — then regenerate with `./gradlew :platform:common:architecture:updateArchitectureDocumentation`.
+- Exempt a declaration that genuinely can't conform with `@ArchitectureException(ruleIds = ["..."])` ([docs/exceptions.md](./platform/common/architecture/docs/exceptions.md)), only with human sign-off.
 - Comment discipline: see [docs/code-comments.md](./docs/code-comments.md) — a comment must say something the code cannot.
 
 ## Toolchain & constraints
@@ -43,14 +37,6 @@ git submodule update --init --recursive
 ```
 New code may rely on APIs that only exist in a newer submodule commit.
 
-## Running
-
-- **Desktop**: `./gradlew :app:client:desktop:run`
-- **Server** (Ktor): `./gradlew :app:server:run` — boots against an embedded Postgres that keeps its data between runs; see Server persistence
-- **Web** (dev server): `./gradlew :app:client:web:wasmJsBrowserDevelopmentRun --no-configuration-cache` — then open the served URL (the flag is required; see the config-cache note in Compiling)
-- **Android**: run from Android Studio, or `./gradlew :app:client:android:installDebug` to a connected device/emulator
-- **iOS**: open `app/client/ios/iosApp.xcodeproj` in Xcode and run (⌘R). There is no Gradle command: the Xcode project's "Compile Kotlin framework" build phase invokes `:app:client:common:embedAndSignAppleFrameworkForXcode`, which builds `App.framework` and puts it where the linker expects. Simulator builds are **Apple Silicon only** — `:app:client:common` declares `iosArm64` + `iosSimulatorArm64`, so the Xcode project excludes the `x86_64` simulator slice. Add an `iosX64()` target if you need Intel Macs.
-
 ## Building as an agent
 
 Agents often run several at a time — subagents in one session, plus other sessions and other projects on the same machine. Nothing coordinates them, so each build has to be a good citizen on its own. The failure mode isn't a slow build, it's a machine that stops being usable: once memory is oversubscribed the box swaps, and swapping stalls everything, not just Gradle.
@@ -65,59 +51,16 @@ In order of leverage:
 4. **Throttle a background build** with `--max-workers=2`. Use a small *fixed* cap rather than a fraction of the core count: you can't know how many agents are running, and a per-agent fraction still multiplies by the number of agents, whereas a fixed cap bounds what each one contributes. A **foreground** build — one the user is waiting on — should not be throttled; it should finish fast.
 5. **Never override daemon memory on an invocation.** Passing `org.gradle.jvmargs` or `kotlin.daemon.jvmargs` on the command line means the running daemon no longer matches, so a new one is forked — asking for less memory gets you more of it. Those belong in `gradle.properties`, one value shared by everyone. For the same reason keep flags identical across agents doing the same kind of work: daemons are matched on their JVM args, so inconsistent flags fragment the daemon pool.
 
-## Compiling
+## Verification
 
-After making changes, compile every platform (client + server) to verify correctness:
-```
-./gradlew :app:client:android:compileDebugKotlin \
-          :app:client:desktop:compileKotlin \
-          :app:client:web:compileKotlinWasmJs \
-          :app:client:common:compileKotlinIosArm64 \
-          :app:client:common:compileKotlinIosSimulatorArm64 \
-          :app:server:compileKotlin
-```
-The common module's Android / JVM / wasm targets compile transitively via the per-platform app modules; the iOS targets are built directly from `:app:client:common`. There is no `:app:client:ios` **Gradle** module — the iOS app is an Xcode project at `app/client/ios`, which consumes `App.framework` from `:app:client:common`. Compiling the iOS targets does **not** exercise the app: the Compose/Enro entry point (`iosMain/MainViewController.kt`) is only executed when the Xcode app runs, so a change to it must be verified by actually launching the app.
+After changes, compile every platform (client + server), not just the touched module — use the `ukpt-verify` skill for the full sweep and test commands. Paparazzi and `wasmJsBrowser*` tasks require `--no-configuration-cache`; the skill documents which tasks and why.
 
-**Web (wasm) caveat — compiling is not enough.** `compileKotlinWasmJs` only type-checks; it does **not** catch failures at wasm bundle time or runtime, so for any web change build the actual bundle and run it in a browser (the `ukpt-verify-web` skill catalogs the failure modes — `node:` imports, the missing ViewModel factory, the `.DS_Store` IC crash — and how to diagnose each):
-```
-./gradlew :app:client:web:wasmJsBrowserDevelopmentWebpack --no-configuration-cache   # bundles via webpack — surfaces node:/IC errors
-./gradlew :app:client:web:wasmJsBrowserDevelopmentRun --no-configuration-cache        # serves it — open the URL and confirm it renders
-```
-`--no-configuration-cache` is **required** on both: the Kotlin plugin's `KotlinWebpack` task holds a `Project` reference and an unserializable `SoftReference`, so it cannot be stored in the configuration cache (upstream). Everything else, including `compileKotlinWasmJs`, is cache-clean.
+## Reference
 
-## Testing
-
-- **Template integrity**: `./gradlew validateTemplate` — validates template metadata, migrations,
-  shared agent guidance, and skills. `./gradlew -p build-logic test` runs the validator and safe
-  project-rename planner's unit tests.
-- **Architecture rules**: `./gradlew :platform:common:architecture:verifyArchitecture` — a standalone task that always re-executes (no `--rerun-tasks` needed; the module's plain `test` task runs nothing — the test classes are plugin-generated from the `UkptArchitecture` definition, not checked in). The suite reports **one nested test per rule** (`<Layer> › <Construct> › <rule>`), so a failure names the exact rule. After changing a rule or an examples file, regenerate the generated docs (README + `docs/`): `./gradlew :platform:common:architecture:updateArchitectureDocumentation`.
-- **UI snapshots** are preview-driven: every `@Preview` composable is discovered by `PreviewSnapshotTest` and snapshotted with Paparazzi (`ClientUi.Composable.screenContentPreview` requires a `@Preview` per ScreenContent). Screen previews wrap their content in the design module's `UkptPreviewFrame`, and each module's `PreviewSnapshotTest` renders in `RenderingMode.SHRINK`, cropping the golden to that frame — so a screen golden reads as a device screenshot, not a render padded to the harness canvas. Record then verify goldens, per client module:
-```
-./gradlew :feature:core:client:recordPaparazzi --no-configuration-cache
-./gradlew :feature:core:client:verifyPaparazzi --no-configuration-cache
-```
-`--no-configuration-cache` is **required** on both: under the configuration cache the R class is dropped from the test runtime classpath and every snapshot test dies with `ClassNotFoundException: <module>.R`.
-
-  Goldens are **directory-grouped** by the preview's declaring package and function name, so a preview in `feature.ukpt.client.ui` lands at `src/androidHostTest/snapshots/images/feature/ukpt/client/ui/UkptScreenPreview.png`. `DirectorySnapshotHandler` (a custom Paparazzi `SnapshotHandler`) implements that layout; stock Paparazzi can only emit one long flat filename per golden. Two previews resolving to the same golden path fail fast at test-parameter creation rather than silently overwriting one another.
-- **Unit tests**: per KMP module via the umbrella task, e.g. `./gradlew :feature:core:api:allTests :feature:core:client:allTests` — a client module's `allTests` includes the snapshot host test, so it needs `--no-configuration-cache` too (same R-class failure as above). Server coverage lives in **two** modules: `./gradlew :feature:core:server:test :app:server:test` — the feature module holds nearly all of it; `:app:server:test` alone runs only the shell's own tests.
-
-## UI atlas
-
-`./gradlew generateUiAtlas` scans the repo for Enro `@NavigationDestination` nodes, `.open()` navigation edges, and Paparazzi goldens, then writes `build/ui-atlas/`: an interactive `index.html` and a machine-readable `manifest.json` (plus copied golden images). Goldens must already exist — run `recordPaparazzi` first if screens are missing images. The `ukpt-ui-atlas` skill documents the manifest schema and how agents should use it for orientation.
-
-## Server persistence (Postgres)
-
-Server persistence uses the `dev.isaacudy.udytils.postgres` toolkit (Exposed + Flyway); conventions are in [docs/serverdata.md](./platform/common/architecture/docs/serverdata.md) (the `server.data.storage` section). `:platform:server:postgres` owns the Flyway migrations (`src/main/resources/db/migration/`, empty until the first schema) and the codegen that turns them into Exposed `Table`/`Row` sources; `:platform:server:development` owns the dev-database scenarios.
-
-`./gradlew :app:server:run` needs no database of your own — it starts an embedded Postgres, migrates it, seeds a brand-new one from `DefaultScenario`, and prints a banner saying where it is. The data lives in `app/server/build/dev-postgres/pg<major>/` and survives restarts (and `clean` therefore wipes it, as does `./gradlew :app:server:wipeDevDatabase`). The switches:
-
-- `UKPT_DEV_DB` — `embedded` (persistent, the `run` default), `ephemeral` (a throwaway cluster on a random port), or anything else to connect to a real Postgres from `POSTGRES_URL` / `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_MAX_POOL_SIZE`. Set it in the invoking environment and `run` yields to you.
-- `UKPT_DEV_DB_DIR` — where a persistent cluster lives; `run` points it at the build directory.
-- `UKPT_DEV_SCENARIO` — names a `DevScenarios` entry to seed a **new** cluster with. Seeding is once-per-cluster; asking for a scenario over existing data fails rather than inserting on top.
-- `PORT` — what the server listens on, default 8080.
-
-## Server packaging
-
-`./gradlew :app:server:buildFatJar` builds the deployable, minus the dev database: Zonky's embedded Postgres, its per-platform binaries and `:platform:server:development` are filtered out of the Shadow jar (`ukpt.server-packaging`). `run` and the tests are unaffected — they use the normal runtime classpath.
-
-Two checks exist because a fat jar can silently drop things. `verifyRuntimeServiceFiles` (part of `check`, and gates `shadowJar`) fails when two runtime dependencies declare the same `META-INF/services` path, since only one copy survives packaging — `flyway-core` and `flyway-database-postgresql` do, which is why `app/server/src/main/resources/META-INF/services/` holds a hand-merged copy (its README says when to regenerate it). **Do not trust Shadow's `mergeServiceFiles()`**: it is called and, on 9.1.0, does not merge — verify by extracting the file from a built jar. `./gradlew :app:server:smokeTestFatJar` then boots the built jar the way a container would, on an OS-assigned port against a throwaway database, and asserts it migrates and answers; nothing else exercises the jar itself.
+- **Running the app**: `ukpt-run` — per-platform run commands, the dev database (embedded Postgres, env switches, seeding, wipe).
+- **Web verification**: `ukpt-verify-web` — bundle and runtime gates for the four wasm-only failure modes.
+- **UI atlas**: `ukpt-ui-atlas` — `./gradlew generateUiAtlas`, manifest schema, agent orientation.
+- **Server packaging**: `ukpt-server-packaging` — fat jar build, service-file collision checks, smoke test.
+- **Feature scaffolding**: `ukpt-feature-slice` — scaffold `:feature:<name>:{api,client,server}`.
+- **urpc services**: `ukpt-urpc-service` — add or change a client/server `@Urpc` service end-to-end.
+- **Design system**: `ukpt-design-system` — establish or extend the project's design system.

--- a/docs/template-migrations/2026-07-09-client-common-module-rename.md
+++ b/docs/template-migrations/2026-07-09-client-common-module-rename.md
@@ -42,7 +42,7 @@ The project is affected if it still has an `:app:client:shared` module — check
 
 5. Search the project for any remaining `:app:client:shared` / `app/client/shared` /
    `projects.app.client.shared` references — comments, docs, CI, scripts — and update them. The
-   template's own compile command (in `UKPT.md`) now targets `:app:client:common:compileKotlinIosArm64`
+   compile command (in the `ukpt-verify` skill) now targets `:app:client:common:compileKotlinIosArm64`
    and `:app:client:common:compileKotlinIosSimulatorArm64`.
 
 ## Verification

--- a/docs/template-migrations/2026-07-13.1-configuration-cache.md
+++ b/docs/template-migrations/2026-07-13.1-configuration-cache.md
@@ -38,7 +38,7 @@ Two task families genuinely cannot use the cache and must be run with `--no-conf
 - **`recordPaparazzi` / `verifyPaparazzi`** — under the cache the R class is dropped from the test
   runtime classpath, so every snapshot test dies with `ClassNotFoundException: <module>.R`.
 
-Both are documented at their call sites in UKPT.md and in the `ukpt-verify-web` /
+Both are documented in the `ukpt-verify` skill and the `ukpt-verify-web` /
 `ukpt-feature-slice` skills.
 
 ## Detection

--- a/docs/template-migrations/2026-08-19.1-progressive-disclosure.md
+++ b/docs/template-migrations/2026-08-19.1-progressive-disclosure.md
@@ -7,14 +7,13 @@ pins, architecture pointer, submodule sync) and one-line pointers to the skills.
 
 ## Detection
 
-N/A — UKPT.md is template-owned and syncs via the normal three-way merge (clean for projects that
-never edited it, as required).
+UKPT.md is template-owned and syncs via the normal three-way merge (clean for projects that never
+edited it, as required).
 
 ## Migration
 
-No manual changes required. The normal template sync updates UKPT.md and adds the three new skill
-directories under `.agents/skills/` and their compatibility symlinks under `.claude/skills/` as new
-template-owned files.
+No manual changes required. The template sync updates UKPT.md and adds the three new skills under
+`.agents/skills/` with their `.claude/skills/` compatibility symlinks.
 
 ## Verification
 

--- a/docs/template-migrations/2026-08-19.1-progressive-disclosure.md
+++ b/docs/template-migrations/2026-08-19.1-progressive-disclosure.md
@@ -1,0 +1,23 @@
+# UKPT.md restructured for progressive disclosure
+
+Reference material moved from UKPT.md into three new skills: `ukpt-verify` (compiling and testing),
+`ukpt-run` (per-platform run commands and the dev database), and `ukpt-server-packaging` (fat jar
+build and verification). UKPT.md retains the always-needed guidance (build constraints, toolchain
+pins, architecture pointer, submodule sync) and one-line pointers to the skills.
+
+## Detection
+
+N/A — UKPT.md is template-owned and syncs via the normal three-way merge (clean for projects that
+never edited it, as required).
+
+## Migration
+
+No manual changes required. The normal template sync updates UKPT.md and adds the three new skill
+directories under `.agents/skills/` and their compatibility symlinks under `.claude/skills/` as new
+template-owned files.
+
+## Verification
+
+```bash
+./gradlew validateTemplate
+```

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.jvmargs=-Xmx3072M -Dfile.encoding=UTF-8
 #     `Project` reference and an unserializable `SoftReference` (NodeJsRootPluginApplier). Upstream.
 #   - record/verifyPaparazzi — the R class is dropped from the test runtime classpath under the
 #     cache, so the snapshot tests die with `ClassNotFoundException: …R`.
-# Both are documented at their call sites in UKPT.md.
+# Both are documented in the `ukpt-verify` skill.
 #
 # NOTE for anyone debugging a new `cannot serialize DefaultProject` / `Gradle script object
 # references` failure: suspect a `doFirst`/`doLast` closure in a build script before blaming the


### PR DESCRIPTION
## Summary

Every agent session and subagent loads the full `CLAUDE.md → AGENTS.md → UKPT.md` stack before doing anything; UKPT.md alone was ~5k tokens of mostly-unused reference. This restructures it for progressive disclosure: **UKPT.md drops from 17,038 to 8,582 bytes (~50%)**, keeping only rules an agent must know *before* acting, with reference material moved behind three new skills that load at the moment of need.

Sorting test applied to every section: *"will an agent break something if it doesn't know this before acting?"* Yes → stays inline; lookup-at-moment-of-need → moves behind a skill with a one-line pointer.

**Stays inline:** the full "Building as an agent" section (machine-citizenship build rules), toolchain pins, submodule sync, the architecture catalog structure + generated-docs guard, template-ownership header, comment-discipline pointer, `--no-configuration-cache` warnings, and one-sentence verification imperatives pointing at skills.

**New skills** (following the existing `.agents/skills/` layout, with `.claude/skills` symlinks and Codex metadata):
- `ukpt-verify` — six-target compile sweep, architecture verification + doc regeneration, `validateTemplate` scope, Paparazzi record/verify + golden layout, per-module tests; delegates web runtime checks to the existing `ukpt-verify-web`
- `ukpt-run` — per-platform run commands (incl. iOS/Xcode) + the full dev-Postgres section (env switches, wipe, seeding)
- `ukpt-server-packaging` — `buildFatJar`, `verifyRuntimeServiceFiles`, the Shadow `mergeServiceFiles()` distrust warning, `smokeTestFatJar`

**Mechanics:** `templateVersion` → `2026-08-19.1` with a no-action migration entry (UKPT.md syncs via the normal three-way merge); five existing skills repointed off removed UKPT.md sections; three stale prose references fixed (`gradle.properties`, two older migration entries).

## Review & verification

- Two Codex review rounds (plan + diff) — findings folded in: restored the architecture catalog-structure facts, `validateTemplate` guarantees and skill-rot warning, the versioning-rule exemption, and corrected the migration entry's merge description.
- Grep audit: every operational fact from the old UKPT.md survives in exactly one canonical home.
- `./gradlew validateTemplate` and `./gradlew -p build-logic test` pass.
- **Downstream acceptance test**: full `ukpt-template-update` run against a throwaway clone of groundtruth applied cleanly end-to-end — two mechanical UKPT.md merge conflicts (downstream's renamed copies of the removed sections vs. their deletion; resolve by taking the template side), migration walk correct, downstream `validateTemplate` green.

## Known issue flagged (pre-existing, not fixed here)

Skills are never rename-mapped downstream (`ukpt-new-project` forbids renaming `.agents/`), so downstream skills state template identifier spellings (`UKPT_DEV_DB`, `UkptPreviewFrame`, `feature.ukpt.*`) that renamed projects don't use — groundtruth's existing `ukpt-verify-web` already has this class of error. This PR widens the surface (content moved from rename-mapped UKPT.md into non-rename-mapped skills), so the two affected new skills carry a "your project renames these identifiers — check `.ukpt/template.json`" note as mitigation. The systemic fix (rename-map skills vs. a rename-neutral wording sweep) is a separate design decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)