### PR TITLE
Tell agents to verify architecture by running the checker, not reading the catalog

### DIFF
--- a/UKPT.md
+++ b/UKPT.md
@@ -51,6 +51,16 @@ In order of leverage:
 4. **Throttle a background build** with `--max-workers=2`. Use a small *fixed* cap rather than a fraction of the core count: you can't know how many agents are running, and a per-agent fraction still multiplies by the number of agents, whereas a fixed cap bounds what each one contributes. A **foreground** build — one the user is waiting on — should not be throttled; it should finish fast.
 5. **Never override daemon memory on an invocation.** Passing `org.gradle.jvmargs` or `kotlin.daemon.jvmargs` on the command line means the running daemon no longer matches, so a new one is forked — asking for less memory gets you more of it. Those belong in `gradle.properties`, one value shared by everyone. For the same reason keep flags identical across agents doing the same kind of work: daemons are matched on their JVM args, so inconsistent flags fragment the daemon pool.
 
+## Checking architecture rules as an agent
+
+For most changes, don't start in the rule catalog. `./gradlew verifyArchitecture` runs in seconds, is incremental, and its failure output is scoped to the violation: the rule ID, its statement, its rationale, and one line per violating declaration. Membership and exhaustiveness failures also list the closest Constructs with a per-requirement checklist of what the declaration missed.
+
+1. **Write the code by copying the nearest existing example.** `:feature:core` is the worked example; the neighbours in the module being edited are the next best thing.
+2. **Run `./gradlew verifyArchitecture`.** Cheap enough to run speculatively.
+3. **Look up only the rule ID that failed.** [`docs/rule-index.md`](./platform/common/architecture/docs/rule-index.md) maps the ID to its declaring source, and the layer page explains it with examples.
+
+Read more widely when the change is shaped by the rules — a new feature slice or subsystem, a Construct the catalog does not have yet, a refactor that moves declarations between layers — and stop once the shape is clear. For small and medium edits it does not pay: the index states rules, while only the engine states how they are tested, so a front-to-back read can still miss the answer (`ClientUi.exhaustive` reads "every top-level declaration must match exactly one Construct"; that `private` declarations are exempt appears only in the engine's classification code).
+
 ## Verification
 
 After changes, compile every platform (client + server), not just the touched module — the `ukpt-verify` skill has the full sweep and test commands. Paparazzi and `wasmJsBrowser*` tasks require `--no-configuration-cache`.

--- a/platform/common/architecture/docs/rule-index.md
+++ b/platform/common/architecture/docs/rule-index.md
@@ -7,6 +7,8 @@
 
 The complete catalog, one row per Construct or Rule. IDs are based on the object/property that declares the entry (see the [README](../README.md)). Enforcement markers link to the declaring source and are explained below the table.
 
+**This index is a lookup table, not a starting point.** To write ordinary code, copy the nearest existing example and run `./gradlew :platform:common:architecture:verifyArchitecture` — its failure output names the failed rule's ID and statement, and for membership and exhaustiveness failures lists the closest Constructs with a per-requirement checklist. Come here for an ID that has already failed, or when adding a Construct or designing a new subsystem.
+
 | Rule | Statement | Enforcement |
 | --- | --- | --- |
 | `ModuleRules.featureNotApp` | A `:feature` module must never depend on an `:app` module | [tested](../src/main/kotlin/architecture/rules/module/ModuleRules.kt) |


### PR DESCRIPTION
## Why

A transcript from a downstream project showed an agent spending ~15k tokens across a 6-turn serial chain reading `rule-index.md` and then the engine source to settle one yes/no question — *does a private top-level function violate exhaustiveness?* — that `verifyArchitecture` answers in seconds, scoped to the violation. The catalog read couldn't even resolve it: the private-declaration exemption lives only in the engine's classification code, not in any rule statement. The tooling was already right; only the guidance was missing.

## What

- **UKPT.md**: new *Checking architecture rules as an agent* section — copy the nearest existing example, run `./gradlew verifyArchitecture`, look up only the rule ID that failed; read the catalog widely only when the change is shaped by the rules (new slice/subsystem/Construct, cross-layer refactor).
- **Submodule repin**: `embedded-udytils` → main (`f51f52e`), picking up [udytils #28](https://github.com/isaac-udy/udytils/pull/28), which renders the same redirect at the top of every generated rule-index page (via the existing `DocsConfig.verifyCommand` — nothing hardcoded). The repin also brings in v1.4.0 and udytils #27 from main.
- **Regenerated docs**: `platform/common/architecture/docs/rule-index.md` is the only generated file that moved.

## Versioning

Template-owned file changes only — no `templateVersion` bump or migration entry needed per UKPT.md's own rules.

## Verification

- `verifyArchitecture` passes on the new pin; docs regeneration produces no further diff.
- `validateTemplate` fails in a fresh worktree on pre-existing missing `build/ui-atlas` / `build/reports/ukpt` outputs referenced by ukpt-ui-atlas and ukpt-new-project SKILL.md files — unrelated to this change (fails identically with these changes stashed), worth a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)