### PR TITLE
Wire enro-test and add real ViewModel unit tests to the worked example

### DIFF
--- a/.agents/skills/ukpt-feature-slice/SKILL.md
+++ b/.agents/skills/ukpt-feature-slice/SKILL.md
@@ -46,7 +46,7 @@ whatever the project was renamed to downstream — read `platform/client/design`
    every ScreenContent to be called from a `@Preview`, and the preview wraps it in
    `<Prefix>PreviewFrame` so the golden reads as a device screenshot rather than a render on the
    harness canvas.
-5. **Wire it up** — the easy-to-forget edits to existing files (templates.md §8 checklist):
+5. **Wire it up** — the easy-to-forget edits to existing files (templates.md §9 checklist):
    - `app/client/common/build.gradle.kts` → `implementation(projects.feature.<name>.client)`.
    - `app/client/common/.../App.kt` → add `<name>ClientDependencies` to `modules(...)` + its import.
    - `app/server/build.gradle.kts` → `implementation(projects.feature.<name>.server)` (if using the server).
@@ -58,7 +58,7 @@ whatever the project was renamed to downstream — read `platform/client/design`
    module, and `./gradlew :platform:common:architecture:verifyArchitecture`. If the feature has web UI, run
    the `ukpt-verify-web` skill — a forgotten `viewModelOf` only crashes at runtime on wasm, invisible to compile.
 
-## Dialogs are destinations, not screen state (templates.md §7)
+## Dialogs are destinations, not screen state (templates.md §8)
 A screen that needs a dialog (confirm, editor, picker) does **not** get a boolean visibility flag
 in its `State` — it gets a new destination. A dialog destination follows the same screen conventions
 as any other: it has its own ViewModel (registered in Koin — the wasm crash from a missing

--- a/.agents/skills/ukpt-feature-slice/templates.md
+++ b/.agents/skills/ukpt-feature-slice/templates.md
@@ -103,6 +103,7 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutinesTest)
+            implementation(libs.enro.test)
         }
         getByName("androidHostTest").dependencies {
             // The snapshot harness: preview discovery, directory-grouped goldens, the
@@ -444,7 +445,80 @@ val <name>ClientDependencies = module {
    A framed screen preview's golden is exactly the frame — the scaffold default is 390 x 844 dp, a
    tall phone at `<Prefix>Viewport.Default`'s width.
 
-## §7 — Dialogs (copy from `:feature:core`, don't template)
+## §7 — ViewModel unit tests
+
+`:client` → `feature/<name>/client/src/commonTest/kotlin/feature/<name>/client/ui/<Name>ViewModelTest.kt`
+```kotlin
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package feature.<name>.client.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.enro.result.NavigationResultChannel
+import dev.enro.test.putNavigationHandleForViewModel
+import dev.enro.test.runEnroTest
+import dev.isaacudy.udytils.state.AsyncState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class <Name>ViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val createdViewModels = mutableListOf<ViewModel>()
+
+    private fun <T : ViewModel> T.track(): T {
+        createdViewModels += this
+        return this
+    }
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        // Cancel each ViewModel's scope before resetting Main: a collector left subscribed
+        // to pendingResults dispatches to a Main dispatcher that no longer exists on targets
+        // without a default one, failing an unrelated test.
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
+        NavigationResultChannel.pendingResults.value = emptyMap()
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun loadLifecycleReachesSuccess() = runEnroTest {
+        // val dataFlow = MutableStateFlow(/* domain projection */)
+        val handle = putNavigationHandleForViewModel<<Name>ViewModel, <Name>Destination>(<Name>Destination)
+
+        val vm = <Name>ViewModel(
+            // flowOf<Name> = FlowOf<Name> { dataFlow },
+        ).track()
+
+        assertIs<AsyncState.Success<*>>(vm.state.value.data)
+    }
+}
+```
+`putNavigationHandleForViewModel` must be called BEFORE the ViewModel is constructed — it pre-registers
+the `TestNavigationHandle` that `by navigationHandle()` resolves at init time. `UnconfinedTestDispatcher`
+ensures `viewModelScope` coroutines execute eagerly. The teardown ordering is load-bearing: scope
+cancellation before `resetMain` prevents a leaked collector from dispatching to a dead dispatcher.
+`:feature:core`'s `UkptViewModelTest` is the complete worked example covering load lifecycle, error +
+retry, actions, and dialog result channels.
+
+## §8 — Dialogs (copy from `:feature:core`, don't template)
+
 No skeleton here — the worked example is the copy-me:
 `feature/core/client/src/commonMain/kotlin/feature/ukpt/client/ui/ConfirmResetDestination.kt` +
 `ConfirmResetDialogScreen.kt` + `ConfirmResetViewModel.kt`, opened from
@@ -461,7 +535,7 @@ dialog returns data that complete/close cannot represent. The destination carrie
 (`ClientUi.ViewModelState.noDialogVisibilityFlags`, `ClientUi.Composable.dialogPrimitivesOnlyInDialogDestinations`,
 `ClientUi.dialogsCommunicateViaResults`).
 
-## §8 — Wiring checklist (edits to EXISTING files — the easy-to-forget step)
+## §9 — Wiring checklist (edits to EXISTING files — the easy-to-forget step)
 - [ ] `settings.gradle.kts` — three `include(":feature:<name>:…")` (§4).
 - [ ] `app/client/common/build.gradle.kts` — `commonMain` → `implementation(projects.feature.<name>.client)`.
 - [ ] `app/client/common/src/commonMain/kotlin/com/isaacudy/ukpt/App.kt` — `import feature.<name>.<name>ClientDependencies`

--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-08-28"
+  "templateVersion": "2026-08-29"
 }

--- a/docs/template-migrations/2026-08-29-viewmodel-testing.md
+++ b/docs/template-migrations/2026-08-29-viewmodel-testing.md
@@ -1,0 +1,59 @@
+# ViewModel unit testing
+
+The `enro-test` dependency, a ViewModel test pattern using `putNavigationHandleForViewModel` and
+result-simulation APIs, and a test skeleton in the `ukpt-feature-slice` scaffold.
+
+## What changed
+
+**enro submodule repin.** The embedded enro submodule is repinned to a main that includes the
+result-simulation API: `sendResultForTest`, `sendCompletedForTest`, and `sendClosedForTest`
+extensions on `NavigationKey.Instance`. These let tests simulate a child destination completing,
+closing, or returning a typed result to the ViewModel's `registerForNavigationResult` channel.
+
+**`enro-test` catalog entry and dependency.** `libs.enro.test` is added to `gradle/libs.versions.toml`
+(no version -- resolves through the composite `includeBuild` substitution like the other enro
+artifacts). `:feature:core:client` and the `ukpt-feature-slice` `:client` template add it as a
+`commonTest` dependency alongside `kotlinx-coroutinesTest`.
+
+**ViewModel test pattern.** `UkptViewModelTest` in `:feature:core:client` demonstrates the full
+pattern:
+
+- `putNavigationHandleForViewModel<VM, K>(key)` pre-registers a `TestNavigationHandle` -- call it
+  BEFORE constructing the ViewModel, because `by navigationHandle()` resolves at init time.
+- `Dispatchers.setMain(UnconfinedTestDispatcher())` replaces Main so `viewModelScope` coroutines
+  and result-channel observers execute eagerly.
+- Each test wraps in `runEnroTest { }`, constructs the VM with hand-written fakes for domain
+  interfaces, and asserts against `vm.state.value`.
+- Teardown ordering is load-bearing: cancel each constructed ViewModel's `viewModelScope` BEFORE
+  `Dispatchers.resetMain()`. A leaked collector subscribed to `pendingResults` would be woken by a
+  later test's `registerResult` and dispatch to a Main dispatcher that no longer exists on targets
+  without a default one. Clear `pendingResults` between tests.
+
+**Test file reorganization.** The domain and infrastructure tests previously in `UkptViewModelTest.kt`
+(`FlowOfGreetingSummaryImplTest`, `GreetingRepositoryTest`, `AsyncStateLoadTest`) are moved to files
+named after the class under test.
+
+**Updated `ukpt-feature-slice` templates.** The `:client` build template includes `libs.enro.test` in
+`commonTest`. A new templates.md section (SS7) provides a minimal ViewModel test skeleton with the
+`putNavigationHandleForViewModel` + `setMain` + tracked-teardown pattern.
+
+## Detection
+
+```bash
+./gradlew :feature:core:client:jvmTest
+```
+
+## Migration
+
+Add `enro-test` to the version catalog and to each feature client module's `commonTest` dependencies.
+Copy the test pattern from `:feature:core:client`'s `UkptViewModelTest` or the `ukpt-feature-slice`
+template skeleton. The teardown ordering (scope cancel before `resetMain`) is non-negotiable -- test
+isolation fails without it.
+
+## Verification
+
+```bash
+./gradlew :feature:core:client:jvmTest
+./gradlew verifyArchitecture
+./gradlew validateTemplate
+```

--- a/feature/core/client/build.gradle.kts
+++ b/feature/core/client/build.gradle.kts
@@ -49,6 +49,7 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotlin.test)
             implementation(libs.kotlinx.coroutinesTest)
+            implementation(libs.enro.test)
         }
         getByName("androidHostTest").dependencies {
             // The snapshot harness: preview discovery, directory-grouped goldens, the

--- a/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/data/GreetingRepositoryTest.kt
+++ b/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/data/GreetingRepositoryTest.kt
@@ -1,7 +1,6 @@
-package feature.ukpt.client.ui
+package feature.ukpt.client.data
 
 import feature.ukpt.Greeting
-import feature.ukpt.client.data.GreetingRepository
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test

--- a/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/domain/FlowOfGreetingSummaryImplTest.kt
+++ b/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/domain/FlowOfGreetingSummaryImplTest.kt
@@ -1,9 +1,6 @@
-package feature.ukpt.client.ui
+package feature.ukpt.client.domain
 
 import feature.ukpt.Greeting
-import feature.ukpt.client.domain.FlowOfGreetingHistory
-import feature.ukpt.client.domain.FlowOfGreetingSummaryImpl
-import feature.ukpt.client.domain.FlowOfLatestGreeting
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf

--- a/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/ui/AsyncStateLoadTest.kt
+++ b/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/ui/AsyncStateLoadTest.kt
@@ -1,0 +1,71 @@
+package feature.ukpt.client.ui
+
+import dev.isaacudy.udytils.state.AsyncState
+import dev.isaacudy.udytils.state.fromFlow
+import dev.isaacudy.udytils.state.fromSuspending
+import dev.isaacudy.udytils.state.isLoading
+import dev.isaacudy.udytils.state.isSuccess
+import feature.ukpt.Greeting
+import feature.ukpt.client.domain.GreetingSummary
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AsyncStateLoadTest {
+
+    @Test
+    fun fromFlowProducesLoadingThenSuccess() = runTest {
+        val summary = GreetingSummary(
+            latestGreeting = Greeting(text = "Hello"),
+            greetingHistory = listOf(Greeting(text = "Hello")),
+        )
+        val states = AsyncState.fromFlow(flowOf(summary)).toList()
+
+        assertTrue(states[0].isLoading())
+        assertIs<AsyncState.Success<GreetingSummary>>(states[1])
+        assertEquals(summary, (states[1] as AsyncState.Success).data)
+    }
+
+    @Test
+    fun fromFlowCapturesError() = runTest {
+        val states = AsyncState.fromFlow(
+            flow<GreetingSummary> { throw IllegalStateException("connection failed") }
+        ).toList()
+
+        assertTrue(states[0].isLoading())
+        assertIs<AsyncState.Error<GreetingSummary>>(states[1])
+    }
+
+    @Test
+    fun fromSuspendingCapturesError() = runTest {
+        val states = AsyncState.fromSuspending<Unit> {
+            throw IllegalStateException("network error")
+        }.toList()
+
+        assertTrue(states[0].isLoading())
+        assertIs<AsyncState.Error<Unit>>(states[1])
+    }
+
+    @Test
+    fun fromSuspendingRetryViaRelaunch() = runTest {
+        var callCount = 0
+        val run = {
+            AsyncState.fromSuspending<Unit> {
+                callCount++
+                if (callCount == 1) throw IllegalStateException("first attempt fails")
+            }
+        }
+
+        val first = run().toList()
+        assertIs<AsyncState.Error<Unit>>(first.last())
+
+        val second = run().toList()
+        assertTrue(second.last().isSuccess())
+        assertEquals(2, callCount)
+    }
+}

--- a/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/ui/FlowOfGreetingSummaryImplTest.kt
+++ b/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/ui/FlowOfGreetingSummaryImplTest.kt
@@ -1,0 +1,64 @@
+package feature.ukpt.client.ui
+
+import feature.ukpt.Greeting
+import feature.ukpt.client.domain.FlowOfGreetingHistory
+import feature.ukpt.client.domain.FlowOfGreetingSummaryImpl
+import feature.ukpt.client.domain.FlowOfLatestGreeting
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class FlowOfGreetingSummaryImplTest {
+
+    @Test
+    fun combinesLatestGreetingAndHistory() = runTest {
+        val impl = FlowOfGreetingSummaryImpl(
+            flowOfLatestGreeting = FlowOfLatestGreeting { flowOf(Greeting(text = "Hello")) },
+            flowOfGreetingHistory = FlowOfGreetingHistory {
+                flowOf(listOf(Greeting(text = "Hello"), Greeting(text = "Hi")))
+            },
+        )
+
+        val result = impl().first()
+        assertEquals(Greeting(text = "Hello"), result.latestGreeting)
+        assertEquals(2, result.greetingHistory.size)
+    }
+
+    @Test
+    fun handlesNullLatestGreeting() = runTest {
+        val impl = FlowOfGreetingSummaryImpl(
+            flowOfLatestGreeting = FlowOfLatestGreeting { flowOf(null) },
+            flowOfGreetingHistory = FlowOfGreetingHistory { flowOf(emptyList()) },
+        )
+
+        val result = impl().first()
+        assertNull(result.latestGreeting)
+        assertTrue(result.greetingHistory.isEmpty())
+    }
+
+    @Test
+    fun updatesWhenSourceChanges() = runTest {
+        val latest = MutableStateFlow<Greeting?>(null)
+        val history = MutableStateFlow<List<Greeting>>(emptyList())
+        val impl = FlowOfGreetingSummaryImpl(
+            flowOfLatestGreeting = FlowOfLatestGreeting { latest },
+            flowOfGreetingHistory = FlowOfGreetingHistory { history },
+        )
+
+        val result1 = impl().first()
+        assertNull(result1.latestGreeting)
+        assertTrue(result1.greetingHistory.isEmpty())
+
+        latest.value = Greeting(text = "Hello")
+        history.value = listOf(Greeting(text = "Hello"))
+
+        val result2 = impl().first()
+        assertEquals(Greeting(text = "Hello"), result2.latestGreeting)
+        assertEquals(1, result2.greetingHistory.size)
+    }
+}

--- a/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/ui/GreetingRepositoryTest.kt
+++ b/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/ui/GreetingRepositoryTest.kt
@@ -1,0 +1,55 @@
+package feature.ukpt.client.ui
+
+import feature.ukpt.Greeting
+import feature.ukpt.client.data.GreetingRepository
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GreetingRepositoryTest {
+
+    @Test
+    fun getGreetingAppendsToHistory() = runTest {
+        val repo = GreetingRepository()
+        repo.getGreeting()
+        val history = repo.flowOfGreetingHistory().first()
+        assertEquals(1, history.size)
+        assertEquals("Hello", history.first().text)
+    }
+
+    @Test
+    fun getGreetingUpdatesLatest() = runTest {
+        val repo = GreetingRepository()
+        assertNull(repo.flowOfLatestGreeting().first())
+
+        repo.getGreeting()
+        assertEquals(Greeting(text = "Hello"), repo.flowOfLatestGreeting().first())
+    }
+
+    @Test
+    fun resetGreetingsClearsList() = runTest {
+        val repo = GreetingRepository()
+        repo.getGreeting()
+        repo.getGreeting()
+        assertEquals(2, repo.flowOfGreetingHistory().first().size)
+
+        repo.resetGreetings()
+        assertTrue(repo.flowOfGreetingHistory().first().isEmpty())
+        assertNull(repo.flowOfLatestGreeting().first())
+    }
+
+    @Test
+    fun multipleGreetsAccumulate() = runTest {
+        val repo = GreetingRepository()
+        repo.getGreeting()
+        repo.getGreeting()
+        repo.getGreeting()
+
+        val history = repo.flowOfGreetingHistory().first()
+        assertEquals(3, history.size)
+        assertEquals(Greeting(text = "Hello"), repo.flowOfLatestGreeting().first())
+    }
+}

--- a/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/ui/UkptViewModelTest.kt
+++ b/feature/core/client/src/commonTest/kotlin/feature/ukpt/client/ui/UkptViewModelTest.kt
@@ -1,173 +1,201 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
 package feature.ukpt.client.ui
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import dev.enro.result.NavigationResultChannel
+import dev.enro.test.assertOpened
+import dev.enro.test.putNavigationHandleForViewModel
+import dev.enro.test.runEnroTest
+import dev.enro.test.sendClosedForTest
+import dev.enro.test.sendCompletedForTest
 import dev.isaacudy.udytils.state.AsyncState
-import dev.isaacudy.udytils.state.fromFlow
-import dev.isaacudy.udytils.state.fromSuspending
-import dev.isaacudy.udytils.state.isLoading
-import dev.isaacudy.udytils.state.isSuccess
 import feature.ukpt.Greeting
-import feature.ukpt.client.data.GreetingRepository
-import feature.ukpt.client.domain.FlowOfGreetingHistory
-import feature.ukpt.client.domain.FlowOfGreetingSummaryImpl
-import feature.ukpt.client.domain.FlowOfLatestGreeting
+import feature.ukpt.client.domain.FlowOfGreetingSummary
+import feature.ukpt.client.domain.GetGreeting
 import feature.ukpt.client.domain.GreetingSummary
+import feature.ukpt.client.domain.ResetGreetings
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.flow.toList
-import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertIs
-import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class FlowOfGreetingSummaryImplTest {
+class UkptViewModelTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private val createdViewModels = mutableListOf<ViewModel>()
+
+    private fun <T : ViewModel> T.track(): T {
+        createdViewModels += this
+        return this
+    }
+
+    @BeforeTest
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    @AfterTest
+    fun tearDown() {
+        // Cancel each ViewModel's scope before resetting Main: a collector left subscribed
+        // to pendingResults dispatches to a Main dispatcher that no longer exists on targets
+        // without a default one, failing an unrelated test.
+        createdViewModels.forEach { it.viewModelScope.cancel() }
+        createdViewModels.clear()
+        NavigationResultChannel.pendingResults.value = emptyMap()
+        Dispatchers.resetMain()
+    }
 
     @Test
-    fun combinesLatestGreetingAndHistory() = runTest {
-        val impl = FlowOfGreetingSummaryImpl(
-            flowOfLatestGreeting = FlowOfLatestGreeting { flowOf(Greeting(text = "Hello")) },
-            flowOfGreetingHistory = FlowOfGreetingHistory {
-                flowOf(listOf(Greeting(text = "Hello"), Greeting(text = "Hi")))
+    fun loadLifecycleReachesSuccessOnEmission() = runEnroTest {
+        val summaryFlow = MutableStateFlow(
+            GreetingSummary(
+                latestGreeting = Greeting(text = "Hello"),
+                greetingHistory = listOf(Greeting(text = "Hello")),
+            )
+        )
+        putNavigationHandleForViewModel<UkptViewModel, UkptDestination>(UkptDestination)
+
+        val vm = UkptViewModel(
+            flowOfGreetingSummary = FlowOfGreetingSummary { summaryFlow },
+            getGreeting = GetGreeting { "Hello" },
+            resetGreetings = ResetGreetings { },
+        ).track()
+
+        val state = vm.state.value
+        assertIs<AsyncState.Success<GreetingSummary>>(state.greetingSummary)
+        assertEquals("Hello", state.greetingSummary.data.latestGreeting?.text)
+        assertEquals(1, state.greetingSummary.data.greetingHistory.size)
+    }
+
+    @Test
+    fun loadErrorLandsInAsyncStateError() = runEnroTest {
+        var shouldFail = true
+        val summaryFlow = MutableStateFlow(
+            GreetingSummary(
+                latestGreeting = null,
+                greetingHistory = emptyList(),
+            )
+        )
+
+        putNavigationHandleForViewModel<UkptViewModel, UkptDestination>(UkptDestination)
+
+        val vm = UkptViewModel(
+            flowOfGreetingSummary = FlowOfGreetingSummary {
+                if (shouldFail) {
+                    flow { throw IllegalStateException("load failed") }
+                } else {
+                    summaryFlow
+                }
             },
+            getGreeting = GetGreeting { "Hello" },
+            resetGreetings = ResetGreetings { },
+        ).track()
+
+        assertIs<AsyncState.Error<GreetingSummary>>(vm.state.value.greetingSummary)
+
+        shouldFail = false
+        vm.onRetryClicked()
+
+        assertIs<AsyncState.Success<GreetingSummary>>(vm.state.value.greetingSummary)
+    }
+
+    @Test
+    fun greetActionDrivesStateToSuccess() = runEnroTest {
+        val summaryFlow = MutableStateFlow(
+            GreetingSummary(latestGreeting = null, greetingHistory = emptyList())
+        )
+        var greetCalled = false
+
+        putNavigationHandleForViewModel<UkptViewModel, UkptDestination>(UkptDestination)
+
+        val vm = UkptViewModel(
+            flowOfGreetingSummary = FlowOfGreetingSummary { summaryFlow },
+            getGreeting = GetGreeting {
+                greetCalled = true
+                "Hello"
+            },
+            resetGreetings = ResetGreetings { },
+        ).track()
+
+        vm.onGreetClicked()
+
+        assertTrue(greetCalled)
+        assertIs<AsyncState.Success<Unit>>(vm.state.value.greetAction)
+    }
+
+    @Test
+    fun greetActionErrorLandsInAsyncStateError() = runEnroTest {
+        val summaryFlow = MutableStateFlow(
+            GreetingSummary(latestGreeting = null, greetingHistory = emptyList())
         )
 
-        val result = impl().first()
-        assertEquals(Greeting(text = "Hello"), result.latestGreeting)
-        assertEquals(2, result.greetingHistory.size)
+        putNavigationHandleForViewModel<UkptViewModel, UkptDestination>(UkptDestination)
+
+        val vm = UkptViewModel(
+            flowOfGreetingSummary = FlowOfGreetingSummary { summaryFlow },
+            getGreeting = GetGreeting { throw IllegalStateException("greet failed") },
+            resetGreetings = ResetGreetings { },
+        ).track()
+
+        vm.onGreetClicked()
+
+        assertIs<AsyncState.Error<Unit>>(vm.state.value.greetAction)
     }
 
     @Test
-    fun handlesNullLatestGreeting() = runTest {
-        val impl = FlowOfGreetingSummaryImpl(
-            flowOfLatestGreeting = FlowOfLatestGreeting { flowOf(null) },
-            flowOfGreetingHistory = FlowOfGreetingHistory { flowOf(emptyList()) },
+    fun resetViaDialogCompletionTriggersResetGreetings() = runEnroTest {
+        val summaryFlow = MutableStateFlow(
+            GreetingSummary(latestGreeting = null, greetingHistory = emptyList())
         )
+        var resetCalled = false
 
-        val result = impl().first()
-        assertNull(result.latestGreeting)
-        assertTrue(result.greetingHistory.isEmpty())
+        val handle = putNavigationHandleForViewModel<UkptViewModel, UkptDestination>(UkptDestination)
+
+        val vm = UkptViewModel(
+            flowOfGreetingSummary = FlowOfGreetingSummary { summaryFlow },
+            getGreeting = GetGreeting { "Hello" },
+            resetGreetings = ResetGreetings { resetCalled = true },
+        ).track()
+
+        vm.onResetRequested()
+        val child = handle.assertOpened<ConfirmResetDestination>()
+        child.sendCompletedForTest()
+
+        assertTrue(resetCalled)
     }
 
     @Test
-    fun updatesWhenSourceChanges() = runTest {
-        val latest = MutableStateFlow<Greeting?>(null)
-        val history = MutableStateFlow<List<Greeting>>(emptyList())
-        val impl = FlowOfGreetingSummaryImpl(
-            flowOfLatestGreeting = FlowOfLatestGreeting { latest },
-            flowOfGreetingHistory = FlowOfGreetingHistory { history },
+    fun resetDialogClosedDoesNotTriggerResetGreetings() = runEnroTest {
+        val summaryFlow = MutableStateFlow(
+            GreetingSummary(latestGreeting = null, greetingHistory = emptyList())
         )
+        var resetCalled = false
 
-        val result1 = impl().first()
-        assertNull(result1.latestGreeting)
-        assertTrue(result1.greetingHistory.isEmpty())
+        val handle = putNavigationHandleForViewModel<UkptViewModel, UkptDestination>(UkptDestination)
 
-        latest.value = Greeting(text = "Hello")
-        history.value = listOf(Greeting(text = "Hello"))
+        val vm = UkptViewModel(
+            flowOfGreetingSummary = FlowOfGreetingSummary { summaryFlow },
+            getGreeting = GetGreeting { "Hello" },
+            resetGreetings = ResetGreetings { resetCalled = true },
+        ).track()
 
-        val result2 = impl().first()
-        assertEquals(Greeting(text = "Hello"), result2.latestGreeting)
-        assertEquals(1, result2.greetingHistory.size)
-    }
-}
+        vm.onResetRequested()
+        val child = handle.assertOpened<ConfirmResetDestination>()
+        child.sendClosedForTest()
 
-class GreetingRepositoryTest {
-
-    @Test
-    fun getGreetingAppendsToHistory() = runTest {
-        val repo = GreetingRepository()
-        repo.getGreeting()
-        val history = repo.flowOfGreetingHistory().first()
-        assertEquals(1, history.size)
-        assertEquals("Hello", history.first().text)
-    }
-
-    @Test
-    fun getGreetingUpdatesLatest() = runTest {
-        val repo = GreetingRepository()
-        assertNull(repo.flowOfLatestGreeting().first())
-
-        repo.getGreeting()
-        assertEquals(Greeting(text = "Hello"), repo.flowOfLatestGreeting().first())
-    }
-
-    @Test
-    fun resetGreetingsClearsList() = runTest {
-        val repo = GreetingRepository()
-        repo.getGreeting()
-        repo.getGreeting()
-        assertEquals(2, repo.flowOfGreetingHistory().first().size)
-
-        repo.resetGreetings()
-        assertTrue(repo.flowOfGreetingHistory().first().isEmpty())
-        assertNull(repo.flowOfLatestGreeting().first())
-    }
-
-    @Test
-    fun multipleGreetsAccumulate() = runTest {
-        val repo = GreetingRepository()
-        repo.getGreeting()
-        repo.getGreeting()
-        repo.getGreeting()
-
-        val history = repo.flowOfGreetingHistory().first()
-        assertEquals(3, history.size)
-        assertEquals(Greeting(text = "Hello"), repo.flowOfLatestGreeting().first())
-    }
-}
-
-class AsyncStateLoadTest {
-
-    @Test
-    fun fromFlowProducesLoadingThenSuccess() = runTest {
-        val summary = GreetingSummary(
-            latestGreeting = Greeting(text = "Hello"),
-            greetingHistory = listOf(Greeting(text = "Hello")),
-        )
-        val states = AsyncState.fromFlow(flowOf(summary)).toList()
-
-        assertTrue(states[0].isLoading())
-        assertIs<AsyncState.Success<GreetingSummary>>(states[1])
-        assertEquals(summary, (states[1] as AsyncState.Success).data)
-    }
-
-    @Test
-    fun fromFlowCapturesError() = runTest {
-        val states = AsyncState.fromFlow(
-            flow<GreetingSummary> { throw IllegalStateException("connection failed") }
-        ).toList()
-
-        assertTrue(states[0].isLoading())
-        assertIs<AsyncState.Error<GreetingSummary>>(states[1])
-    }
-
-    @Test
-    fun fromSuspendingCapturesError() = runTest {
-        val states = AsyncState.fromSuspending<Unit> {
-            throw IllegalStateException("network error")
-        }.toList()
-
-        assertTrue(states[0].isLoading())
-        assertIs<AsyncState.Error<Unit>>(states[1])
-    }
-
-    @Test
-    fun fromSuspendingRetryViaRelaunch() = runTest {
-        var callCount = 0
-        val run = {
-            AsyncState.fromSuspending<Unit> {
-                callCount++
-                if (callCount == 1) throw IllegalStateException("first attempt fails")
-            }
-        }
-
-        val first = run().toList()
-        assertIs<AsyncState.Error<Unit>>(first.last())
-
-        val second = run().toList()
-        assertTrue(second.last().isSuccess())
-        assertEquals(2, callCount)
+        // Absence is the assertion: sendClosedForTest must not invoke resetGreetings.
+        assertTrue(!resetCalled)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -77,6 +77,7 @@ konsist = { module = "com.lemonappdev:konsist", version.ref = "konsist" }
 
 enro-core = { module = "dev.enro:enro" }
 enro-common = { module = "dev.enro:enro-common" }
+enro-test = { module = "dev.enro:enro-test" }
 enro-processor = { module = "dev.enro:enro-processor" }
 
 udytils-core = { module = "dev.isaacudy.udytils:core" }


### PR DESCRIPTION
## Summary

Closes the gap left by the async-UI-state work: `UkptViewModel` had no direct unit tests because `by navigationHandle<>()` resolves at ViewModel construction. Enro's result-simulation API (Enro PR #225, now on main) makes the full pattern testable in common code.

- **Repins `embedded-enro`** to main (result-simulation API: `sendResultForTest` / `sendCompletedForTest` / `sendClosedForTest`).
- **Wires `dev.enro:enro-test`** into the version catalog and `:feature:core:client` commonTest (composite-build substitution, no version).
- **Real `UkptViewModelTest`** (6 tests): load lifecycle to Success, load error + retry after the fake is repaired, greet-action lifecycle and error, and the dialog result round-trip — `onResetRequested()` asserted via `assertOpened<ConfirmResetDestination>()`, `sendCompletedForTest()` triggers `ResetGreetings`, `sendClosedForTest()` does not. Uses the leak-safe teardown established in enro (cancel tracked ViewModel scopes → clear `pendingResults` → `resetMain`), with the constraint documented where it matters.
- **Test layout fixed**: the domain/data stand-in tests that lived in a file named `UkptViewModelTest` moved to files and packages matching the classes under test (`data/GreetingRepositoryTest`, `domain/FlowOfGreetingSummaryImplTest`, `ui/AsyncStateLoadTest`).
- **Scaffolding**: `ukpt-feature-slice` templates now include a ViewModel-test skeleton (register handle before construction, Main dispatcher setup, tracked teardown) and add `enro-test` to the scaffolded `:client` build; `templateVersion` bumped to `2026-08-29` with migration entry `docs/template-migrations/2026-08-29-viewmodel-testing.md`.

## Test plan

- `:feature:core:client:jvmTest` — all tests pass, including the 6 new ViewModel tests.
- `verifyArchitecture` — green, only the 2 pre-existing advisory findings.
- `validateTemplate` — green.
- `:feature:core:client:compileKotlinIosArm64`, `compileKotlinJvm`, `compileKotlinWasmJs` — commonTest additions break no target compilation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)