### PR TITLE
Bump Ktor from 3.5.1 to 3.5.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotlinx-io = "0.9.1"
 kotlinx-browser = "0.5.0"
 koin = "4.2.2"
 ksp = "2.3.9"
-ktor = "3.5.1"
+ktor = "3.5.2"
 logback = "1.5.37"
 # Not applied anywhere — the Ktor plugin applies Shadow — but build-logic compiles against the
 # ShadowJar type, and Ktor keeps Shadow out of its consumable compile metadata. Keep this equal to


### PR DESCRIPTION
## Summary

- Bumps `ktor` from 3.5.1 to 3.5.2 in `gradle/libs.versions.toml`.
- Picks up KTOR-9704 (UTF-8 encoding bypass of JVM `String.getBytes` intrinsics — 5-7x text-response slowdown), KTOR-9741 (CIO coroutine leak on half-closed idle connections after >=1MB responses), and KTOR-9679 (`ByteReadChannel.readLine` corrupting multi-byte UTF-8 at buffer boundaries).

## Shadow version coupling

Verified via `./gradlew :app:server:buildEnvironment`: Ktor 3.5.2 brings `com.gradleup.shadow:shadow-gradle-plugin:9.1.0`, matching the existing `shadow` pin in the version catalog. No change needed.

## Test plan

- [ ] `./gradlew verifyArchitecture`
- [ ] Full compile sweep (Desktop, wasmJs, Android, iOS, JVM)
- [ ] `buildFatJar` + `smokeTestFatJar` — confirms Shadow `mergeServiceFiles()` works at runtime
- [ ] Service-file collision check on the fat jar

🤖 Generated with [Claude Code](https://claude.com/claude-code)