### PR TITLE
Name build artifacts after the module path so installDist works

### DIFF
--- a/.agents/skills/ukpt-run/SKILL.md
+++ b/.agents/skills/ukpt-run/SKILL.md
@@ -26,6 +26,10 @@ reload), use `ukpt-drive-app`.
 ```
 Boots against an embedded Postgres that keeps its data between runs; see Dev database below.
 
+To run it outside Gradle, `./gradlew :app:server:installDist` writes a launcher and every module jar
+to `app/server/build/install/server/`; start it with `bin/server` and the same env switches. The
+`ukpt-server-packaging` skill covers how those jars are named.
+
 ## Web (dev server)
 
 ```

--- a/.agents/skills/ukpt-server-packaging/SKILL.md
+++ b/.agents/skills/ukpt-server-packaging/SKILL.md
@@ -3,10 +3,13 @@ name: ukpt-server-packaging
 description: >-
   Build, verify, and deploy the server fat jar — buildFatJar, runtime
   service-file collision checks, Shadow 9.1.0's mergeServiceFiles() silently not
-  merging, and smokeTestFatJar. Use when packaging or deploying the server.
+  merging, smokeTestFatJar, and the installDist development distribution and its
+  archive naming. Use when packaging or deploying the server.
 ---
 
 # ukpt-server-packaging
+
+Identifiers here use the template's UKPT identity (`UKPT_DEV_DB`); projects rename these — the map is in `.ukpt/template.json`.
 
 `./gradlew :app:server:buildFatJar` builds the deployable, minus the dev database: Zonky's embedded
 Postgres, its per-platform binaries and `:platform:server:development` are filtered out of the
@@ -31,3 +34,22 @@ verify by extracting the file from a built jar.
 ```
 Boots the built jar the way a container would, on an OS-assigned port against a throwaway database,
 and asserts it migrates and answers. Nothing else exercises the jar itself.
+
+## Development distribution
+
+```
+./gradlew :app:server:installDist
+UKPT_DEV_DB=ephemeral app/server/build/install/server/bin/server
+```
+Unlike the fat jar this keeps every module as its own file under `lib/`, and it keeps the dev
+database. It is the "run the server outside Gradle" path, not the deployable.
+
+Module jars are named after the full project path (`feature-core-server.jar`,
+`platform-server-postgres.jar`), set by `ukpt.jvm-base` and `ukpt.kmp-library` through
+`ukpt.ArchiveNaming`. Gradle's default name is the leaf directory, which a project laid out by
+feature repeats: every `:*:server` module produces `server.jar`, and copying them into one `lib/`
+fails on the duplicate entry. A `duplicatesStrategy` on `installDist` is not the fix — the
+colliding files are different modules, so whichever strategy applies drops a feature's classes.
+
+The fat jar keeps the name Ktor's `buildFatJar` gives it (`server-all.jar`), which it pins
+independently of `archivesName`.

--- a/.ukpt/template.json
+++ b/.ukpt/template.json
@@ -1,3 +1,3 @@
 {
-  "templateVersion": "2026-09-10"
+  "templateVersion": "2026-09-10.1"
 }

--- a/build-logic/src/main/kotlin/ukpt.jvm-base.gradle.kts
+++ b/build-logic/src/main/kotlin/ukpt.jvm-base.gradle.kts
@@ -1,13 +1,20 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import ukpt.ArchiveNaming
 
 /**
  * Base convention for every plain Kotlin/JVM module in the project.
  *
  * Applies: KotlinJvm
- * Configures: Java/Kotlin bytecode target and shared Kotlin compiler options.
+ * Configures: archive naming, Java/Kotlin bytecode target and shared Kotlin compiler options.
  */
 plugins {
     id("org.jetbrains.kotlin.jvm")
+}
+
+base {
+    // Artifact names must be unique across the whole build: `installDist` copies every module's jar
+    // into one `lib/`, and Gradle's default name is the leaf directory, which features repeat.
+    archivesName.set(ArchiveNaming.baseNameFor(project.path))
 }
 
 java {

--- a/build-logic/src/main/kotlin/ukpt.kmp-library.gradle.kts
+++ b/build-logic/src/main/kotlin/ukpt.kmp-library.gradle.kts
@@ -1,13 +1,15 @@
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import ukpt.ArchiveNaming
 
 /**
  * Convention plugin for Kotlin Multiplatform library modules.
  *
  * Applies: KotlinMultiplatform + the AGP 9 Android KMP library plugin
  * (`com.android.kotlin.multiplatform.library`).
- * Configures: All KMP targets (Android, iOS, JVM, WasmJS), compiler options, Android defaults.
+ * Configures: archive naming, all KMP targets (Android, iOS, JVM, WasmJS), compiler options,
+ * Android defaults.
  *
  * The Android target is configured via the `kotlin { androidLibrary { } }` accessor. Both
  * submodules use the same name, and it resolves on every AGP 9.x (the `android` alias only
@@ -24,6 +26,12 @@ plugins {
 private val libs = versionCatalogs.named("libs")
 private val androidCompileSdk = libs.findVersion("android-compileSdk").get().requiredVersion.toInt()
 private val androidMinSdk = libs.findVersion("android-minSdk").get().requiredVersion.toInt()
+
+base {
+    // Same constraint as ukpt.jvm-base: the jvm target's jar reaches the server's runtime
+    // classpath, where every `:feature:*:api` would otherwise be `api-jvm.jar`.
+    archivesName.set(ArchiveNaming.baseNameFor(project.path))
+}
 
 kotlin {
     @Suppress("UnstableApiUsage")

--- a/build-logic/src/main/kotlin/ukpt/ArchiveNaming.kt
+++ b/build-logic/src/main/kotlin/ukpt/ArchiveNaming.kt
@@ -1,0 +1,16 @@
+package ukpt
+
+/**
+ * Derives a module's `archivesName` from its full Gradle path.
+ *
+ * Gradle's default is the leaf directory, which repeats across a project laid out by feature:
+ * `:app:server`, `:feature:core:server` and every other `:feature:*:server` would all produce
+ * `server.jar`, and every `:feature:*:api` an `api-jvm.jar`. Any task that gathers the runtime
+ * classpath into one directory — `installDist` — then fails on the duplicate entry.
+ */
+object ArchiveNaming {
+    fun baseNameFor(projectPath: String): String =
+        projectPath.trim(':')
+            .replace(':', '-')
+            .ifEmpty { "root" }
+}

--- a/build-logic/src/test/kotlin/ukpt/ArchiveNamingTest.kt
+++ b/build-logic/src/test/kotlin/ukpt/ArchiveNamingTest.kt
@@ -1,0 +1,36 @@
+package ukpt
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ArchiveNamingTest {
+
+    @Test
+    fun flattensAProjectPathIntoAnArtifactName() {
+        assertEquals("app-server", ArchiveNaming.baseNameFor(":app:server"))
+        assertEquals("feature-core-api", ArchiveNaming.baseNameFor(":feature:core:api"))
+        assertEquals("platform-server-postgres", ArchiveNaming.baseNameFor(":platform:server:postgres"))
+    }
+
+    @Test
+    fun givesModulesSharingALeafDirectoryDistinctNames() {
+        val paths = listOf(
+            ":app:server",
+            ":feature:core:api",
+            ":feature:core:server",
+            ":feature:accounts:api",
+            ":feature:accounts:server",
+            ":platform:server:postgres",
+            ":platform:server:development",
+        )
+
+        val names = paths.map(ArchiveNaming::baseNameFor)
+
+        assertEquals(names.size, names.toSet().size, "colliding archive names: $names")
+    }
+
+    @Test
+    fun fallsBackToARootNameForTheRootProject() {
+        assertEquals("root", ArchiveNaming.baseNameFor(":"))
+    }
+}

--- a/docs/template-migrations/2026-09-10.1-module-path-archive-names.md
+++ b/docs/template-migrations/2026-09-10.1-module-path-archive-names.md
@@ -1,0 +1,57 @@
+# Build artifacts are named after the module path
+
+`ukpt.jvm-base` and `ukpt.kmp-library` now set `archivesName` from the full Gradle project path,
+via a new `ukpt.ArchiveNaming` helper in build-logic. `:feature:core:server` produces
+`feature-core-server.jar` instead of `server.jar`, `:feature:core:api` produces
+`feature-core-api-jvm.jar` instead of `api-jvm.jar`, and `:app:server` produces
+`app-server-1.0.0.jar` instead of `server-1.0.0.jar`. Android AARs, wasm klibs and iOS klibs from
+`ukpt.kmp-library` and `ukpt.compose-library` are renamed the same way.
+
+Gradle's default archive name is the leaf directory, which is not unique in a project laid out by
+feature: every `:*:server` module produced `server.jar` and every `:feature:*:api` produced
+`api-jvm.jar`. `:app:server:installDist` copies the whole runtime classpath into one `lib/` and
+fails on the second one with `Entry lib/server.jar is a duplicate but no duplicate handling
+strategy has been set`. A project reaches this the moment it has a second `:feature:*:server`.
+
+A `duplicatesStrategy` on `installDist` is not the fix: the colliding files are different modules,
+so any strategy that resolves the name drops one module's classes from the distribution.
+
+## Detection
+
+The convention plugins arrive with the file sync — build-logic is template-owned. What can only
+exist downstream is a reference to an artifact by its old name, or a module that sets
+`archivesName` itself.
+
+```bash
+grep -rn "archivesName\|archiveBaseName\|archiveFileName" --include=*.kts .
+grep -rn "server\.jar\|api-jvm\.jar\|build/libs\|build/install" \
+  Dockerfile* */Dockerfile* .github docs *.md 2>/dev/null
+```
+
+A reference matched by glob (`*-all.jar`) or taken from a task's `archiveFile` provider needs
+nothing. A literal module jar name does.
+
+## Migration
+
+1. Take `build-logic/src/main/kotlin/ukpt/ArchiveNaming.kt`, its test, and the `base { }` blocks in
+   `ukpt.jvm-base.gradle.kts` and `ukpt.kmp-library.gradle.kts`. A project whose convention plugins
+   have diverged from the template applies the same two blocks by hand.
+2. Rewrite any literal artifact name found above. Prefer a glob or the task's `archiveFile`
+   provider over a new literal — the name changes again if the module moves.
+3. A module that sets `archivesName` for its own reasons keeps it: the convention only supplies a
+   default that module-level configuration overrides. Check the name it sets is still unique.
+
+The fat jar is unchanged. Ktor's `buildFatJar` pins `server-all.jar` independently of
+`archivesName`, so a `*-all.jar` glob in a Dockerfile or deploy workflow keeps matching, and
+`build/install/server/` and `bin/server` come from the distribution name rather than the archive
+name.
+
+## Verification
+
+```bash
+./gradlew -p build-logic test
+./gradlew :app:server:installDist && ls app/server/build/install/server/lib/
+./gradlew :app:server:smokeTestFatJar
+```
+
+`lib/` holding one file per project module, with no name repeated, is the check that matters.


### PR DESCRIPTION
Gradle names a module's archives after its leaf directory. In a project laid out by feature that name is not unique: `:app:server` and `:feature:core:server` both produce `server.jar`, and every `:feature:*:api` produces `api-jvm.jar`. `:app:server:installDist` copies the whole runtime classpath into one `lib/` and fails on the duplicate entry.

The template as it stands doesn't hit this — its one feature slice makes every name distinct by accident. Adding a second `:feature:*:server` is enough:

```
> Entry lib/server.jar is a duplicate but no duplicate handling strategy has been set.
```

`ukpt.jvm-base` and `ukpt.kmp-library` now set `archivesName` from the full project path via a new `ukpt.ArchiveNaming` helper. A `duplicatesStrategy` on `installDist` is the wrong fix — the colliding files are different modules, so any strategy that resolves the name drops one module's classes from the distribution.

### Renamed artifacts

| Module | Was | Now |
| --- | --- | --- |
| `:app:server` | `server-1.0.0.jar` | `app-server-1.0.0.jar` |
| `:feature:core:server` | `server.jar` | `feature-core-server.jar` |
| `:feature:core:api` | `api-jvm.jar` | `feature-core-api-jvm.jar` |
| `:platform:server:postgres` | `postgres.jar` | `platform-server-postgres.jar` |
| `:platform:server:development` | `development.jar` | `platform-server-development.jar` |
| `:app:client:desktop` | `desktop.jar` | `app-client-desktop.jar` |

The same rule applies to the other `ukpt.kmp-library` / `ukpt.compose-library` modules (`:feature:core:client`, `:platform:client:*`, `:app:client:common`) across their JVM, Android, wasm and iOS outputs.

**Unchanged:** the fat jar. Ktor's `buildFatJar` pins `server-all.jar` independently of `archivesName`, so the deployable is the same task output — confirmed by building it. `build/install/server/` and `bin/server` come from the distribution name, not the archive name. `ukpt.snapshot-testing-base`'s stub-`R.jar` hook uses a fixed AGP intermediates path, so Paparazzi is unaffected.

The repo has no Dockerfile or CI workflow, so nothing here referenced an artifact by name. The migration entry gives downstream projects the greps for the places that do (Dockerfile, deploy workflow, scripts) and says to prefer a `*-all.jar` glob or a task's `archiveFile` provider over a new literal.

### Docs and tests

- `.agents/skills/ukpt-server-packaging/SKILL.md` — new "Development distribution" section: how to build and start it, the naming rule and why, and that `duplicatesStrategy` is the wrong fix
- `.agents/skills/ukpt-run/SKILL.md` — pointer from the server run section to `installDist`
- `build-logic/src/test/kotlin/ukpt/ArchiveNamingTest.kt` — path flattening, the root-project fallback, and that a project with two feature slices gets distinct names
- `docs/template-migrations/2026-09-10.1-module-path-archive-names.md`, `templateVersion` → `2026-09-10.1`

### Verification

Reproduced first: added a throwaway `:feature:demo:server`, confirmed `installDist` fails with the duplicate-entry error, applied the fix, confirmed it succeeds and `lib/` holds `feature-core-server.jar` and `feature-demo-server.jar` side by side, then removed the module.

All run one at a time:

- `:app:server:installDist` — succeeds; `lib/` holds one file per project module, no name repeated
- installed launcher, `UKPT_DEV_DB=ephemeral PORT=8123 bin/server` — `Flyway migration complete`, `Dev database: embedded-ephemeral`, `Responding at http://0.0.0.0:8123`; `GET /` returned 200 `Hello, ukpt server!`; stopped
- `:app:server:buildFatJar :app:server:verifyRuntimeServiceFiles :app:server:smokeTestFatJar` — pass, output still named `server-all.jar`
- `:app:client:android:checkDebugAarMetadata :app:client:android:compileDebugKotlin` — pass
- `:app:client:desktop:createDistributable` — pass
- `:app:client:web:wasmJsBrowserDevelopmentWebpack --no-configuration-cache` — pass
- `:app:client:common:linkDebugFrameworkIosSimulatorArm64` — pass
- `:platform:client:design:verifyPaparazzi :feature:core:client:verifyPaparazzi --no-configuration-cache` — pass
- `:app:server:test :feature:core:server:test :app:client:common:jvmTest` — pass
- `./gradlew -p build-logic test`, `validateTemplate`, `verifyArchitecture` — pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TJo9czthTCg6UXV5zf4mxA
